### PR TITLE
Add Nothing Phone 3 support (6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | `6.6.89-android15-8-g0889fe95bb10-ab14402178-4k`       | POCO X8 Pro Max                                                  |
 | `6.6.89-android15-8-gf4dc45704e54-abogki446052083-4k`  | OnePlus 13                                                       |
 | `6.6.92-android15-8-g3637f4904cf5-ab13944661-4k`       | Red Magic Tablet 3 Pro, Red Magic 10 Pro, Red Magic 11 Air       |
+| `6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k`      | Nothing Phone 3                                                  |
 | `6.6.102-android15-8-gb01b41c2647c-ab15574720-4k`      | Xiaomi 17T                                                       |
 | `6.6.102-android15-8-gfe76d1bc97fd-ab14689815-4k`      | Xiaomi 17T                                                       |
 | `6.6.118-android15-8-g2e6b9c3812c5-ab15114928-4k`      | OPPO Find N5                                                     |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -15,6 +15,7 @@
 | `6.6.89-android15-8-g0889fe95bb10-ab14402178-4k`       | POCO X8 Pro Max                                                  |
 | `6.6.89-android15-8-gf4dc45704e54-abogki446052083-4k`  | OnePlus 13                                                       |
 | `6.6.92-android15-8-g3637f4904cf5-ab13944661-4k`       | Red Magic Tablet 3 Pro, Red Magic 10 Pro, Red Magic 11 Air       |
+| `6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k`      | Nothing Phone 3                                                  |
 | `6.6.102-android15-8-gb01b41c2647c-ab15574720-4k`      | Xiaomi 17T                                                       |
 | `6.6.102-android15-8-gfe76d1bc97fd-ab14689815-4k`      | Xiaomi 17T                                                       |
 | `6.6.118-android15-8-g2e6b9c3812c5-ab15114928-4k`      | OPPO Find N5                                                     |

--- a/src/kernels/6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k/offsets.h
+++ b/src/kernels/6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k/offsets.h
@@ -1,0 +1,23 @@
+/* 6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k */
+
+OFFSETS_ENTRY(
+    "6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k",
+    STRUCT_OFFSETS_6_6,
+    .pselect_waiter_shift = -2,
+    .off_init_task = 0x0210e280,
+    .off_init_cred = 0x02120748,
+    .off_root_task_group = 0x02307580,
+    .off_selinux_enforcing = 0x02348eb0,
+    .off_selinux_blob_sizes = 0x016665a8,
+    .off_security_hook_heads = 0x01665e70,
+    .off_slide_nfulnl_logger = 0x02102258,
+    .off_slide_boot_id = 0x02369ea8,
+    .off_slide_loggers_0_1 = 0x021021a8,
+),
+
+/* BTF reference (runtime uses target.h defaults): */
+/* #define STRUCT_PAGE_SIZE 0x40 */
+/* #define STRUCT_PAGE_COMPOUND_HEAD 0x8 */
+/* #define STRUCT_PAGE_TYPE 0x30 */
+/* #define STRUCT_SLAB_CACHE 0x8 */
+/* #define STRUCT_MM_STRUCT 0x4C0 */

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -68,6 +68,7 @@ static const struct kernel_offsets known_offsets[] = {
 #include "6.6.89-android15-8-g0889fe95bb10-ab14402178-4k/offsets.h"
 #include "6.6.89-android15-8-gf4dc45704e54-abogki446052083-4k/offsets.h"
 #include "6.6.92-android15-8-g3637f4904cf5-ab13944661-4k/offsets.h"
+#include "6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k/offsets.h"
 #include "6.6.102-android15-8-gb01b41c2647c-ab15574720-4k/offsets.h"
 #include "6.6.102-android15-8-gfe76d1bc97fd-ab14689815-4k/offsets.h"
 #include "6.6.118-android15-8-g2e6b9c3812c5-ab15114928-4k/offsets.h"


### PR DESCRIPTION
Tested on Metroid_B4.1-260414-1846 build which has the 6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k kernel.

<img width="1260" height="2800" alt="image" src="https://github.com/user-attachments/assets/0eda7db4-a11f-4848-b0d7-889bb3934d18" />
