### PR TITLE
add xiaomi 14 (houji) support (6.1.138-android14-11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 | Kernel                                                 | Devices                                                          |
 | ------------------------------------------------------ |------------------------------------------------------------------|
 | `6.1.118-android14-11-gca0ef6d17716-ab13624819`        | Xiaomi 14                                                        |
+| `6.1.138-android14-11-g0c3d559bcd85-ab14529422`        | Xiaomi 14                                                        |
 | `6.6.30-android15-8-g54dcbfbef792-ab12368803-4k`       | Red Magic Tablet 3 Pro                                           |
 | `6.6.77-android15-8-g4a507830d890-ab13636293-4k`       | Xiaomi Civi 5 Pro, REDMI K90 / 4 Turbo, POCO F7                  |
 | `6.6.77-android15-8-g63ce7556864c-ab13994517-4k`       | Xiaomi 15                                                        |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -7,6 +7,7 @@
 | Kernel                                                 | Devices                                                          |
 | ------------------------------------------------------ |------------------------------------------------------------------|
 | `6.1.118-android14-11-gca0ef6d17716-ab13624819`        | Xiaomi 14                                                        |
+| `6.1.138-android14-11-g0c3d559bcd85-ab14529422`        | Xiaomi 14                                                        |
 | `6.6.30-android15-8-g54dcbfbef792-ab12368803-4k`       | Red Magic Tablet 3 Pro                                           |
 | `6.6.77-android15-8-g4a507830d890-ab13636293-4k`       | Xiaomi Civi 5 Pro, REDMI K90 / 4 Turbo, POCO F7                  |
 | `6.6.77-android15-8-g63ce7556864c-ab13994517-4k`       | Xiaomi 15                                                        |

--- a/src/kernels/6.1.138-android14-11-g0c3d559bcd85-ab14529422/offsets.h
+++ b/src/kernels/6.1.138-android14-11-g0c3d559bcd85-ab14529422/offsets.h
@@ -1,0 +1,23 @@
+/* 6.1.138-android14-11-g0c3d559bcd85-ab14529422 */
+
+OFFSETS_ENTRY(
+    "6.1.138-android14-11-g0c3d559bcd85-ab14529422",
+    STRUCT_OFFSETS_6_1,
+    .pselect_waiter_shift = 1,
+    .off_init_task = 0x01fef600,
+    .off_init_cred = 0x02001a68,
+    .off_root_task_group = 0x021d7580,
+    .off_selinux_enforcing = 0x022293d0,
+    .off_selinux_blob_sizes = 0x015b7788,
+    .off_security_hook_heads = 0x015b7078,
+    .off_slide_nfulnl_logger = 0x01fe29c8,
+    .off_slide_boot_id = 0x0224a458,
+    .off_slide_loggers_0_1 = 0x01fe2918,
+),
+
+/* BTF reference (runtime uses target.h defaults): */
+/* #define STRUCT_PAGE_SIZE 0x40 */
+/* #define STRUCT_PAGE_COMPOUND_HEAD 0x8 */
+/* #define STRUCT_PAGE_TYPE 0x30 */
+/* #define STRUCT_SLAB_CACHE 0x18 */
+/* #define STRUCT_MM_STRUCT 0x3C0 */

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -60,6 +60,7 @@ struct kernel_offsets {
 static const struct kernel_offsets known_offsets[] = {
 /* Add new kernels by creating src/kernels/<uname-release>/offsets.h */
 #include "6.1.118-android14-11-gca0ef6d17716-ab13624819/offsets.h"
+#include "6.1.138-android14-11-g0c3d559bcd85-ab14529422/offsets.h"
 #include "6.6.30-android15-8-g54dcbfbef792-ab12368803-4k/offsets.h"
 #include "6.6.77-android15-8-g4a507830d890-ab13636293-4k/offsets.h"
 #include "6.6.77-android15-8-g63ce7556864c-ab13994517-4k/offsets.h"


### PR DESCRIPTION
adds the hyperos 3.0.302.0 android14 kernel for xiaomi 14 (houji, sm8650): `6.1.138-android14-11-g0c3d559bcd85-ab14529422`