### PR TITLE
add infinix note 50s 5g support (6.1.145-android14-11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 | ------------------------------------------------------ |------------------------------------------------------------------|
 | `6.1.118-android14-11-gca0ef6d17716-ab13624819`        | Xiaomi 14                                                        |
 | `6.1.138-android14-11-g0c3d559bcd85-ab14529422`        | Xiaomi 14                                                        |
+| `6.1.145-android14-11-g09f1c0074ad7-ab14226177`        | Infinix Note 50s 5G                                              |
 | `6.6.30-android15-8-g54dcbfbef792-ab12368803-4k`       | Red Magic Tablet 3 Pro                                           |
 | `6.6.77-android15-8-g4a507830d890-ab13636293-4k`       | Xiaomi Civi 5 Pro, REDMI K90 / 4 Turbo, POCO F7                  |
 | `6.6.77-android15-8-g63ce7556864c-ab13994517-4k`       | Xiaomi 15                                                        |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -8,6 +8,7 @@
 | ------------------------------------------------------ |------------------------------------------------------------------|
 | `6.1.118-android14-11-gca0ef6d17716-ab13624819`        | Xiaomi 14                                                        |
 | `6.1.138-android14-11-g0c3d559bcd85-ab14529422`        | Xiaomi 14                                                        |
+| `6.1.145-android14-11-g09f1c0074ad7-ab14226177`        | Infinix Note 50s 5G                                              |
 | `6.6.30-android15-8-g54dcbfbef792-ab12368803-4k`       | Red Magic Tablet 3 Pro                                           |
 | `6.6.77-android15-8-g4a507830d890-ab13636293-4k`       | Xiaomi Civi 5 Pro, REDMI K90 / 4 Turbo, POCO F7                  |
 | `6.6.77-android15-8-g63ce7556864c-ab13994517-4k`       | Xiaomi 15                                                        |

--- a/src/kernels/6.1.145-android14-11-g09f1c0074ad7-ab14226177/offsets.h
+++ b/src/kernels/6.1.145-android14-11-g09f1c0074ad7-ab14226177/offsets.h
@@ -1,0 +1,24 @@
+/* 6.1.145-android14-11-g09f1c0074ad7-ab14226177 */
+
+OFFSETS_ENTRY(
+    "6.1.145-android14-11-g09f1c0074ad7-ab14226177",
+    STRUCT_OFFSETS_6_1,
+    .kernel_phys_load = 0x8000000,
+    .pselect_waiter_shift = 1,
+    .off_init_task = 0x0200f600,
+    .off_init_cred = 0x02021a68,
+    .off_root_task_group = 0x021f7580,
+    .off_selinux_enforcing = 0x02249400,
+    .off_selinux_blob_sizes = 0x015cb068,
+    .off_security_hook_heads = 0x015ca958,
+    .off_slide_nfulnl_logger = 0x020029c8,
+    .off_slide_boot_id = 0x0226a498,
+    .off_slide_loggers_0_1 = 0x02002918,
+),
+
+/* BTF reference (runtime uses target.h defaults): */
+/* #define STRUCT_PAGE_SIZE 0x40 */
+/* #define STRUCT_PAGE_COMPOUND_HEAD 0x8 */
+/* #define STRUCT_PAGE_TYPE 0x30 */
+/* #define STRUCT_SLAB_CACHE 0x18 */
+/* #define STRUCT_MM_STRUCT 0x3C0 */

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -61,6 +61,7 @@ static const struct kernel_offsets known_offsets[] = {
 /* Add new kernels by creating src/kernels/<uname-release>/offsets.h */
 #include "6.1.118-android14-11-gca0ef6d17716-ab13624819/offsets.h"
 #include "6.1.138-android14-11-g0c3d559bcd85-ab14529422/offsets.h"
+#include "6.1.145-android14-11-g09f1c0074ad7-ab14226177/offsets.h"
 #include "6.6.30-android15-8-g54dcbfbef792-ab12368803-4k/offsets.h"
 #include "6.6.77-android15-8-g4a507830d890-ab13636293-4k/offsets.h"
 #include "6.6.77-android15-8-g63ce7556864c-ab13994517-4k/offsets.h"


### PR DESCRIPTION
adds a kernel table for the infinix note 50s 5G (X6870, MT6878), extracted from the stock boot.img with `tools/extract_rs --register`:

`6.1.145-android14-11-g09f1c0074ad7-ab14226177`

tested.