### PR TITLE
fix infinix note 50s: drop bogus kernel_phys_load

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Kernels are matched by exact `uname -r`; unsupported builds are rejected and the
 
 ## Quick Start
 
-Open **GhostLock** and tap **Run**. KernelSU (`me.weishu.kernelsu`), ReSukiSU (`com.resukisu.resukisu`), or KowsuSuperManager (`com.kowx712.supermanager`) provides `ksud` for module loading; without it, W1/W2 still grant uid 0 but no module is loaded.
+Open **GhostLock** and tap **Run**. KernelSU (`me.weishu.kernelsu`), ReSukiSU (`com.resukisu.resukisu`), or KowSU (`com.kowx712.supermanager`) provides `ksud` for module loading; without it, W1/W2 still grant uid 0 but no module is loaded.
 
 The route races two cores. On the 6.6/6.12 tree-waiter kernels the main thread hammers `select` while a consumer thread perturbs the waiter's priority; on the 6.1 compact-waiter kernels the main thread drives `getsockopt(TCP_ZEROCOPY_RECEIVE)` through a punched-hole page instead (`GHOSTLOCK_TCP_ROUTE=0` forces the pselect route). The pair defaults to the big cores (fallback 0/1), overridable via `GHOSTLOCK_CORE` / `GHOSTLOCK_CONSUMER_CORE`.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -46,7 +46,7 @@
 
 ## 快速开始
 
-打开 **GhostLock** 点击 **执行**。需先装 KernelSU（`me.weishu.kernelsu`）、ReSukiSU（`com.resukisu.resukisu`）或 KowsuSuperManager（`com.kowx712.supermanager`）以提供 `ksud`；缺 `ksud` 时 W1/W2 仍可拿到 uid 0，但不会加载模块。
+打开 **GhostLock** 点击 **执行**。需先装 KernelSU（`me.weishu.kernelsu`）、ReSukiSU（`com.resukisu.resukisu`）或 KowSU（`com.kowx712.supermanager`）以提供 `ksud`；缺 `ksud` 时 W1/W2 仍可拿到 uid 0，但不会加载模块。
 
 路线是双核竞争。6.6/6.12 树形 waiter 内核上主线程跑 `select` 爆破、consumer 线程扰动 waiter 优先级；6.1 紧凑 waiter 内核上主线程改走 `getsockopt(TCP_ZEROCOPY_RECEIVE)` 打洞页写入（`GHOSTLOCK_TCP_ROUTE=0` 强制回退 pselect 路线）。核心对默认取大核（不可用时回退 0/1），可用 `GHOSTLOCK_CORE` / `GHOSTLOCK_CONSUMER_CORE` 覆盖。
 

--- a/src/kernels/6.1.145-android14-11-g09f1c0074ad7-ab14226177/offsets.h
+++ b/src/kernels/6.1.145-android14-11-g09f1c0074ad7-ab14226177/offsets.h
@@ -3,7 +3,6 @@
 OFFSETS_ENTRY(
     "6.1.145-android14-11-g09f1c0074ad7-ab14226177",
     STRUCT_OFFSETS_6_1,
-    .kernel_phys_load = 0x8000000,
     .pselect_waiter_shift = 1,
     .off_init_task = 0x0200f600,
     .off_init_cred = 0x02021a68,

--- a/tools/extract_rs/src/report.rs
+++ b/tools/extract_rs/src/report.rs
@@ -95,11 +95,7 @@ pub fn validate_kernel_phys_load(release: Option<&str>, phys: Option<u64>, mtk: 
     if phys == expected {
         return false;
     }
-    let note = if mtk {
-        "runtime forces the DRAM base for MediaTek"
-    } else {
-        "the entry will carry it as an explicit override"
-    };
+    let note = "the entry will carry it as an explicit override";
     eprintln!(
         "warning: kernel_phys_load=0x{phys:x} does not match the {} default 0x{expected:x}; {note}",
         if mtk { "MediaTek" } else { "Qualcomm" }


### PR DESCRIPTION
my bad, typo'd the phys load one zero short and e5128a9 made it live. also kowsu hehe