### PR TITLE
Add Motorola Razr 60 Ultra support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 | `6.6.118-android15-8-g2e6b9c3812c5-ab15114928-4k`      | OPPO Find N5                                                     |
 | `6.6.118-android15-8-g93e223c276e7-abogki500782043-4k` | OPPO Find X8 Ultra, OnePlus 13 / ACE 5 Pro                       |
 | `6.6.118-android15-8-g608a629fedf7-ab15154340-4k`      | REDMI K90 Ultra                                                  |
+| `6.6.118-android15-8-gbf8cd367de7a-ab15314822-4k`      | Motorola Razr 60 Ultra                                           |
 | `6.6.118-android15-8-gc44b714366cc-abogki519650608-4k` | REDMI K80 Pro / Turbo 5 Max, POCO X8 Pro Max, Xiaomi Pad 7 Ultra |
 | `6.6.118-android15-8-ge56cf6b09cca-ab15511674-4k`      | REDMI K90 Ultra, POCO F7                                         |
 | `6.6.118-android15-8-ge58033dc8ea6-abogki498046332-4k` | OPPO Pad 5, OnePlus Pad 2, OPPO Find X8s                         |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -28,6 +28,7 @@
 | `6.6.118-android15-8-g2e6b9c3812c5-ab15114928-4k`      | OPPO Find N5                                                     |
 | `6.6.118-android15-8-g93e223c276e7-abogki500782043-4k` | OPPO Find X8 Ultra, OnePlus 13 / ACE 5 Pro                       |
 | `6.6.118-android15-8-g608a629fedf7-ab15154340-4k`      | REDMI K90 Ultra                                                  |
+| `6.6.118-android15-8-gbf8cd367de7a-ab15314822-4k`      | Motorola Razr 60 Ultra                                           |
 | `6.6.118-android15-8-gc44b714366cc-abogki519650608-4k` | REDMI K80 Pro / Turbo 5 Max, POCO X8 Pro Max, Xiaomi Pad 7 Ultra |
 | `6.6.118-android15-8-ge56cf6b09cca-ab15511674-4k`      | REDMI K90 Ultra, POCO F7                                         |
 | `6.6.118-android15-8-ge58033dc8ea6-abogki498046332-4k` | OPPO Pad 5, OnePlus Pad 2, OPPO Find X8s                         |

--- a/src/kernels/6.6.118-android15-8-gbf8cd367de7a-ab15314822-4k/offsets.h
+++ b/src/kernels/6.6.118-android15-8-gbf8cd367de7a-ab15314822-4k/offsets.h
@@ -1,0 +1,23 @@
+/* 6.6.118-android15-8-gbf8cd367de7a-ab15314822-4k */
+
+OFFSETS_ENTRY(
+    "6.6.118-android15-8-gbf8cd367de7a-ab15314822-4k",
+    STRUCT_OFFSETS_6_6,
+    .pselect_waiter_shift = -2,
+    .off_init_task = 0x0212e280,
+    .off_init_cred = 0x02140748,
+    .off_root_task_group = 0x02328980,
+    .off_selinux_enforcing = 0x0236a2e0,
+    .off_selinux_blob_sizes = 0x016849f0,
+    .off_security_hook_heads = 0x016842b8,
+    .off_slide_nfulnl_logger = 0x02122260,
+    .off_slide_boot_id = 0x0238b2d8,
+    .off_slide_loggers_0_1 = 0x021221b0,
+),
+
+/* BTF reference (runtime uses target.h defaults): */
+/* #define STRUCT_PAGE_SIZE 0x40 */
+/* #define STRUCT_PAGE_COMPOUND_HEAD 0x8 */
+/* #define STRUCT_PAGE_TYPE 0x30 */
+/* #define STRUCT_SLAB_CACHE 0x8 */
+/* #define STRUCT_MM_STRUCT 0x4C0 */

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -79,6 +79,7 @@ static const struct kernel_offsets known_offsets[] = {
 #include "6.6.118-android15-8-g2e6b9c3812c5-ab15114928-4k/offsets.h"
 #include "6.6.118-android15-8-g93e223c276e7-abogki500782043-4k/offsets.h"
 #include "6.6.118-android15-8-g608a629fedf7-ab15154340-4k/offsets.h"
+#include "6.6.118-android15-8-gbf8cd367de7a-ab15314822-4k/offsets.h"
 #include "6.6.118-android15-8-gc44b714366cc-abogki519650608-4k/offsets.h"
 #include "6.6.118-android15-8-ge56cf6b09cca-ab15511674-4k/offsets.h"
 #include "6.6.118-android15-8-ge58033dc8ea6-abogki498046332-4k/offsets.h"


### PR DESCRIPTION
Add support for the `6.6.118-android15-8-gbf8cd367de7a-ab15314822-4k` kernel, used on the Motorola Razr 60 Ultra (`leap`, `XT2551-6`) as of the latest August security patches (Build ID: `W1VLS36H.59-55-5-11`)

<img height="800" alt="Screenshot_20260903-192344_ReSukiSU" src="https://github.com/user-attachments/assets/42e401c3-d4b3-4e5c-9b20-e1701c5a0fb0" /><img height="800" alt="Screenshot_20260903-192358_GhostLock" src="https://github.com/user-attachments/assets/478fea4b-9a5b-4921-b872-753fd1fda488" />
