### PR TITLE
Add Honor Magic V5 MBH-N49 (6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k 9.0.1.160, v675608)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | `6.6.89-android15-8-g096cdb6ecefc-ab14358676-4k`       | OPPO Pad 4 Pro                                                   |
 | `6.6.89-android15-8-g0889fe95bb10-ab14402178-4k`       | POCO X8 Pro Max                                                  |
 | `6.6.89-android15-8-g8e4be6b47e40-ab14134548-4k`       | POCO X8 Pro                                                      |
+| `6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k`       | Honor Magic V5                                                   |
 | `6.6.89-android15-8-gf4dc45704e54-abogki446052083-4k`  | OnePlus 13                                                       |
 | `6.6.92-android15-8-g3637f4904cf5-ab13944661-4k`       | Red Magic Tablet 3 Pro, Red Magic 10 Pro, Red Magic 11 Air       |
 | `6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k`      | Nothing Phone 3                                                  |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -20,6 +20,7 @@
 | `6.6.89-android15-8-g096cdb6ecefc-ab14358676-4k`       | OPPO Pad 4 Pro                                                   |
 | `6.6.89-android15-8-g0889fe95bb10-ab14402178-4k`       | POCO X8 Pro Max                                                  |
 | `6.6.89-android15-8-g8e4be6b47e40-ab14134548-4k`       | POCO X8 Pro                                                      |
+| `6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k`       | Honor Magic V5                                                   |
 | `6.6.89-android15-8-gf4dc45704e54-abogki446052083-4k`  | OnePlus 13                                                       |
 | `6.6.92-android15-8-g3637f4904cf5-ab13944661-4k`       | Red Magic Tablet 3 Pro, Red Magic 10 Pro, Red Magic 11 Air       |
 | `6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k`      | Nothing Phone 3                                                  |

--- a/src/kernels/6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k/offsets.h
+++ b/src/kernels/6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k/offsets.h
@@ -1,0 +1,23 @@
+/* 6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k */
+
+OFFSETS_ENTRY(
+    "6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k",
+    STRUCT_OFFSETS_6_6,
+    .pselect_waiter_shift = -2,
+    .off_init_task = 0x020de280,
+    .off_init_cred = 0x020f0548,
+    .off_root_task_group = 0x022d5580,
+    .off_selinux_enforcing = 0x02316ea0,
+    .off_selinux_blob_sizes = 0x016509a8,
+    .off_security_hook_heads = 0x01650270,
+    .off_slide_nfulnl_logger = 0x020d2258,
+    .off_slide_boot_id = 0x02337e98,
+    .off_slide_loggers_0_1 = 0x020d21a8,
+),
+
+/* BTF reference (runtime uses target.h defaults): */
+/* #define STRUCT_PAGE_SIZE 0x40 */
+/* #define STRUCT_PAGE_COMPOUND_HEAD 0x8 */
+/* #define STRUCT_PAGE_TYPE 0x30 */
+/* #define STRUCT_SLAB_CACHE 0x8 */
+/* #define STRUCT_MM_STRUCT 0x4C0 */

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -71,6 +71,7 @@ static const struct kernel_offsets known_offsets[] = {
 #include "6.6.89-android15-8-g8e4be6b47e40-ab14134548-4k/offsets.h"
 #include "6.6.89-android15-8-g096cdb6ecefc-ab14358676-4k/offsets.h"
 #include "6.6.89-android15-8-g0889fe95bb10-ab14402178-4k/offsets.h"
+#include "6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k/offsets.h"
 #include "6.6.89-android15-8-gf4dc45704e54-abogki446052083-4k/offsets.h"
 #include "6.6.92-android15-8-g3637f4904cf5-ab13944661-4k/offsets.h"
 #include "6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k/offsets.h"


### PR DESCRIPTION
Add support for Honor Magic V5, was done with 9.0.1.160 OTA (v675608 in hihonorcdn)

Screenshots:
<img width="2172" height="2352" alt="Screenshot_20260904_012231_com_ghostlock_app_MainActivity" src="https://github.com/user-attachments/assets/5d9646f2-48ec-4081-97f1-4b2d826cb004" />
<img width="2172" height="2352" alt="Screenshot_20260904_011736_com_resukisu_resukisu_MainActivity" src="https://github.com/user-attachments/assets/12c1120b-9334-409d-a508-0897a9ec33bf" />
