### PR TITLE
Added Honor Magic V5 MBH-N49 (6.6.89-android15-8-g42db9ecb036b-ab14487600-4k 10.0.0.164, v860396)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 | `6.6.89-android15-8-g096cdb6ecefc-ab14358676-4k`       | OPPO Pad 4 Pro                                                   |
 | `6.6.89-android15-8-g0889fe95bb10-ab14402178-4k`       | POCO X8 Pro Max                                                  |
 | `6.6.89-android15-8-g8e4be6b47e40-ab14134548-4k`       | POCO X8 Pro                                                      |
-| `6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k`       | Honor Magic V5                                                   |
+| `6.6.89-android15-8-g42db9ecb036b-ab14487600-4k`       | Honor Magic V5 (10.0.0.164)                                      |
+| `6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k`       | Honor Magic V5 (9.0.1.160)                                       |
 | `6.6.89-android15-8-gf4dc45704e54-abogki446052083-4k`  | OnePlus 13                                                       |
 | `6.6.92-android15-8-g3637f4904cf5-ab13944661-4k`       | Red Magic Tablet 3 Pro, Red Magic 10 Pro, Red Magic 11 Air       |
 | `6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k`      | Nothing Phone 3                                                  |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -20,7 +20,8 @@
 | `6.6.89-android15-8-g096cdb6ecefc-ab14358676-4k`       | OPPO Pad 4 Pro                                                   |
 | `6.6.89-android15-8-g0889fe95bb10-ab14402178-4k`       | POCO X8 Pro Max                                                  |
 | `6.6.89-android15-8-g8e4be6b47e40-ab14134548-4k`       | POCO X8 Pro                                                      |
-| `6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k`       | Honor Magic V5                                                   |
+| `6.6.89-android15-8-g42db9ecb036b-ab14487600-4k`       | Honor Magic V5 (10.0.0.164)                                      |
+| `6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k`       | Honor Magic V5 (9.0.1.160)                                       |
 | `6.6.89-android15-8-gf4dc45704e54-abogki446052083-4k`  | OnePlus 13                                                       |
 | `6.6.92-android15-8-g3637f4904cf5-ab13944661-4k`       | Red Magic Tablet 3 Pro, Red Magic 10 Pro, Red Magic 11 Air       |
 | `6.6.102-android15-8-gab8eb70a71b8-ab14350911-4k`      | Nothing Phone 3                                                  |

--- a/src/kernels/6.6.89-android15-8-g42db9ecb036b-ab14487600-4k/offsets.h
+++ b/src/kernels/6.6.89-android15-8-g42db9ecb036b-ab14487600-4k/offsets.h
@@ -1,0 +1,23 @@
+/* 6.6.89-android15-8-g42db9ecb036b-ab14487600-4k */
+
+OFFSETS_ENTRY(
+    "6.6.89-android15-8-g42db9ecb036b-ab14487600-4k",
+    STRUCT_OFFSETS_6_6,
+    .pselect_waiter_shift = -2,
+    .off_init_task = 0x020fe280,
+    .off_init_cred = 0x02110548,
+    .off_root_task_group = 0x022f5580,
+    .off_selinux_enforcing = 0x02336ea0,
+    .off_selinux_blob_sizes = 0x016625d0,
+    .off_security_hook_heads = 0x01661e98,
+    .off_slide_nfulnl_logger = 0x020f2258,
+    .off_slide_boot_id = 0x02357e98,
+    .off_slide_loggers_0_1 = 0x020f21a8,
+),
+
+/* BTF reference (runtime uses target.h defaults): */
+/* #define STRUCT_PAGE_SIZE 0x40 */
+/* #define STRUCT_PAGE_COMPOUND_HEAD 0x8 */
+/* #define STRUCT_PAGE_TYPE 0x30 */
+/* #define STRUCT_SLAB_CACHE 0x8 */
+/* #define STRUCT_MM_STRUCT 0x4C0 */

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -69,6 +69,7 @@ static const struct kernel_offsets known_offsets[] = {
 #include "6.6.77-android15-8-g63ce7556864c-ab13994517-4k/offsets.h"
 #include "6.6.77-android15-8-gca30f3b4bef6-abogki440974771-4k/offsets.h"
 #include "6.6.89-android15-8-g8e4be6b47e40-ab14134548-4k/offsets.h"
+#include "6.6.89-android15-8-g42db9ecb036b-ab14487600-4k/offsets.h"
 #include "6.6.89-android15-8-g096cdb6ecefc-ab14358676-4k/offsets.h"
 #include "6.6.89-android15-8-g0889fe95bb10-ab14402178-4k/offsets.h"
 #include "6.6.89-android15-8-gb99b4586a3ee-ab13754593-4k/offsets.h"


### PR DESCRIPTION
Honor Magic V5 on 10.0.0.164 ROM - validated by [ayed78](https://xdaforums.com/t/is-it-possible-to-root-the-honor-magic-v5.4762839/post-90729039)

<img width="300" alt="ghostlock_483552" src="https://github.com/user-attachments/assets/728c4f65-e668-4b2f-a4cb-d8800a932214" />
<img width="300" alt="resukisu_483553" src="https://github.com/user-attachments/assets/faf2ade2-3eb7-45ad-9cc8-8861bae856dd" />
