### PR TITLE
extract_rs: don't emit kernel_phys_load for mtk ota parses

### DIFF
--- a/tools/extract_rs/src/main.rs
+++ b/tools/extract_rs/src/main.rs
@@ -275,28 +275,25 @@ fn run(cli: &Cli) -> Result<i32> {
     if kernel_phys_load.is_none() && (boot.mtk_lz4 || boot.mtk_gzip) {
         if let Some(text_base) = text_base {
             match text_base.checked_sub(MTK_VADDR_BASE) {
-                Some(derived) if derived > 0 && derived <= 0xFFFF_FFFF => {
+                Some(derived) if derived == MTK_DEFAULT_PHYS_LOAD => {
                     eprintln!(
-                        "info: MediaTek compressed image; kernel_phys_load derived \
-                         from _text: 0x{derived:x} (DRAM base; pass --phys to override)"
+                        "info: MediaTek compressed image; _text confirms \
+                         kernel_phys_load=0x{derived:x} (DRAM base)"
                     );
                     kernel_phys_load = Some(derived);
                 }
                 _ => {
                     eprintln!(
-                        "warning: _text=0x{text_base:x} gives no plausible mtk \
-                         kernel_phys_load; using 0x{MTK_DEFAULT_PHYS_LOAD:x} \
-                         (pass --phys to override)"
+                        "warning: _text=0x{text_base:x} does not match the mtk \
+                         DRAM-base mapping; kernel_phys_load left unset so the \
+                         runtime derives it (pass --phys to override)"
                     );
-                    kernel_phys_load = Some(MTK_DEFAULT_PHYS_LOAD);
                 }
             }
         } else {
-            kernel_phys_load = Some(MTK_DEFAULT_PHYS_LOAD);
             eprintln!(
-                "info: MediaTek compressed image; _text unavailable, assuming \
-                 kernel_phys_load=0x{MTK_DEFAULT_PHYS_LOAD:x} (DRAM base; pass \
-                 --phys to override)"
+                "info: MediaTek compressed image; _text unavailable, leaving \
+                 kernel_phys_load unset so the runtime derives it"
             );
         }
     }


### PR DESCRIPTION
mtk _text links at the arm64 default `0xffffffc008000000`, so the extractor derived `0x0800000` instead of the dram base `0x80000000` and baked it into offsets.json. d830514 made imported values win over the runtime derivation, so mtk ota parses should have been freezing the device at the first kernel write.

leave kernel_phys_load unset for mtk; the runtime derives it. this should fix freezes related to wrong kernel_phys_load (#104 #87 #88).

verified on poco x6 pro (mtk 6.1.138)

users with an already-imported offsets.json need to reparse the ota / reimport.