### PR TITLE
feat: add Nothing Phone (3a) Pro offsets; fix on-device hang (kernel_phys_load 0xa8080000, fastest-core default)

### DIFF
--- a/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
@@ -390,6 +390,15 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
             val freq = readMaxFreq(0)
             cpuPairLabels += "0,1" + if (freq > 0) " · ${formatFreq(freq)}" else ""
         }
+        // Prefer the highest-frequency core paired with its sibling. On the
+        // Nothing 3a Pro (SM7635, cpus 4-7 big) this yields (6,7), the pair
+        // verified on-device; the freq-cluster chunking above would otherwise
+        // default to (4,5) and drop the prime core entirely.
+        val fastest = online.maxByOrNull { readMaxFreq(it) }
+        if (fastest != null && fastest > 0 && CpuPair(fastest - 1, fastest) !in cpuPairs) {
+            cpuPairs.add(0, CpuPair(fastest - 1, fastest))
+            cpuPairLabels.add(0, "${fastest - 1},$fastest · ${formatFreq(readMaxFreq(fastest))}")
+        }
     }
 
     private fun restoreCpuPair() {

--- a/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
@@ -390,14 +390,25 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
             val freq = readMaxFreq(0)
             cpuPairLabels += "0,1" + if (freq > 0) " · ${formatFreq(freq)}" else ""
         }
-        // Prefer the highest-frequency core paired with its sibling. On the
-        // Nothing 3a Pro (SM7635, cpus 4-7 big) this yields (6,7), the pair
-        // verified on-device; the freq-cluster chunking above would otherwise
-        // default to (4,5) and drop the prime core entirely.
+        // Prefer the highest-frequency core paired with the next-highest
+        // online core. On the Nothing 3a Pro (SM7635, cpus 4-7 big) this
+        // yields (6,7), the pair verified on-device; the freq-cluster
+        // chunking above would otherwise default to (4,5) and drop the
+        // prime core entirely.
         val fastest = online.maxByOrNull { readMaxFreq(it) }
-        if (fastest != null && fastest > 0 && CpuPair(fastest - 1, fastest) !in cpuPairs) {
-            cpuPairs.add(0, CpuPair(fastest - 1, fastest))
-            cpuPairLabels.add(0, "${fastest - 1},$fastest · ${formatFreq(readMaxFreq(fastest))}")
+        val sibling = fastest?.minus(1)
+        if (fastest != null && sibling != null && sibling >= 0 && sibling in online &&
+            CpuPair(sibling, fastest) !in cpuPairs
+        ) {
+            val fastestFreq = readMaxFreq(fastest)
+            val siblingFreq = readMaxFreq(sibling)
+            val freqLabel = if (siblingFreq == fastestFreq) {
+                formatFreq(fastestFreq)
+            } else {
+                "${formatFreq(siblingFreq)}/${formatFreq(fastestFreq)}"
+            }
+            cpuPairs.add(0, CpuPair(sibling, fastest))
+            cpuPairLabels.add(0, "$sibling,$fastest · $freqLabel")
         }
     }
 

--- a/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
@@ -390,25 +390,35 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
             val freq = readMaxFreq(0)
             cpuPairLabels += "0,1" + if (freq > 0) " · ${formatFreq(freq)}" else ""
         }
-        // Prefer the highest-frequency core paired with the next-highest
-        // online core. On the Nothing 3a Pro (SM7635, cpus 4-7 big) this
-        // yields (6,7), the pair verified on-device; the freq-cluster
-        // chunking above would otherwise default to (4,5) and drop the
-        // prime core entirely.
-        val fastest = online.maxByOrNull { readMaxFreq(it) }
-        val sibling = fastest?.minus(1)
-        if (fastest != null && sibling != null && sibling >= 0 && sibling in online &&
-            CpuPair(sibling, fastest) !in cpuPairs
-        ) {
-            val fastestFreq = readMaxFreq(fastest)
-            val siblingFreq = readMaxFreq(sibling)
-            val freqLabel = if (siblingFreq == fastestFreq) {
-                formatFreq(fastestFreq)
+        // Prefer the two fastest online cores as the default pair, ranked by
+        // frequency with CPU ID as a tie-breaker. A plain maxByOrNull returns
+        // the first of several tied cores and pairing it with its ID sibling
+        // can produce a mixed little/big pair (e.g. (3,4) on a 4+4 layout
+        // where 4-7 tie); the ID-adjacent assumption also breaks when the
+        // neighbour is offline. On the Nothing 3a Pro (SM7635, cpus 4-7 big)
+        // this yields (6,7), the pair verified on-device. Move the pair to
+        // the front even when cluster chunking already added it, so the
+        // chunking cannot mask it.
+        val rankedTopTwo = online
+            .filter { readMaxFreq(it) > 0 }
+            .sortedWith(compareByDescending<Int> { readMaxFreq(it) }.thenByDescending { it })
+            .take(2)
+            .sorted()
+        if (rankedTopTwo.size == 2) {
+            val pair = CpuPair(rankedTopTwo[0], rankedTopTwo[1])
+            val pairFreqs = rankedTopTwo.map { readMaxFreq(it) }
+            val freqLabel = if (pairFreqs[0] == pairFreqs[1]) {
+                formatFreq(pairFreqs[0])
             } else {
-                "${formatFreq(siblingFreq)}/${formatFreq(fastestFreq)}"
+                "${formatFreq(pairFreqs[0])}/${formatFreq(pairFreqs[1])}"
             }
-            cpuPairs.add(0, CpuPair(sibling, fastest))
-            cpuPairLabels.add(0, "$sibling,$fastest · $freqLabel")
+            val existing = cpuPairs.indexOf(pair)
+            if (existing >= 0) {
+                cpuPairs.removeAt(existing)
+                cpuPairLabels.removeAt(existing)
+            }
+            cpuPairs.add(0, pair)
+            cpuPairLabels.add(0, "${pair.primary},${pair.consumer} · $freqLabel")
         }
     }
 

--- a/src/kernels/6.1.157-android14-11-g82d681c9b06b-ab14634535/offsets.h
+++ b/src/kernels/6.1.157-android14-11-g82d681c9b06b-ab14634535/offsets.h
@@ -1,0 +1,24 @@
+/* 6.1.157-android14-11-g82d681c9b06b-ab14634535 */
+
+OFFSETS_ENTRY(
+    "6.1.157-android14-11-g82d681c9b06b-ab14634535",
+    STRUCT_OFFSETS_6_1,
+    .kernel_phys_load = 0xa8080000,
+    .pselect_waiter_shift = 1,
+    .off_init_task = 0x0201f640,
+    .off_init_cred = 0x02031aa8,
+    .off_root_task_group = 0x02208580,
+    .off_selinux_enforcing = 0x0225a420,
+    .off_selinux_blob_sizes = 0x015ce8c8,
+    .off_security_hook_heads = 0x015ce1b8,
+    .off_slide_nfulnl_logger = 0x020129d0,
+    .off_slide_boot_id = 0x0227b498,
+    .off_slide_loggers_0_1 = 0x02012920,
+),
+
+/* BTF reference (runtime uses target.h defaults): */
+/* #define STRUCT_PAGE_SIZE 0x40 */
+/* #define STRUCT_PAGE_COMPOUND_HEAD 0x8 */
+/* #define STRUCT_PAGE_TYPE 0x30 */
+/* #define STRUCT_SLAB_CACHE 0x18 */
+/* #define STRUCT_MM_STRUCT 0x3C0 */

--- a/src/kernels/6.1.157-android14-11-g82d681c9b06b-ab14634535/offsets.h
+++ b/src/kernels/6.1.157-android14-11-g82d681c9b06b-ab14634535/offsets.h
@@ -1,5 +1,11 @@
 /* 6.1.157-android14-11-g82d681c9b06b-ab14634535 */
 
+/* kernel_phys_load override: this firmware loads the kernel image at
+ * 0xa8080000 (xbl_config FDT "Kernel" reserved region), one 0x80000 step
+ * above the QC default 0xa8000000 in target.h. Without the override every
+ * W1/W2 write lands 0x80000 below its target and hangs the kernel (QCOM
+ * watchdog bite). Same image as the A059 JP build; symbols are identical
+ * to its maintainer-verified profile. */
 OFFSETS_ENTRY(
     "6.1.157-android14-11-g82d681c9b06b-ab14634535",
     STRUCT_OFFSETS_6_1,

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -65,6 +65,7 @@ static const struct kernel_offsets known_offsets[] = {
 #include "6.1.145-android14-11-g09f1c0074ad7-ab14226177/offsets.h"
 #include "6.1.145-android14-11-g74d1702dab4d-ab14669069/offsets.h"
 #include "6.1.145-android14-11-geaa643a2c0ee-ab14763719/offsets.h"
+#include "6.1.157-android14-11-g82d681c9b06b-ab14634535/offsets.h"
 #include "6.1.162-android14-11-gce140c0e5bf5-ab15450923/offsets.h"
 #include "6.6.30-android15-8-g54dcbfbef792-ab12368803-4k/offsets.h"
 #include "6.6.77-android15-8-g4a507830d890-ab13636293-4k/offsets.h"


### PR DESCRIPTION
# [PR #118] Add Nothing Phone (3a) Pro support — fix on-device hang/reboot on `6.1.157-android14-11-g82d681c9b06b-ab14634535`

> PR: https://github.com/YuKongA/ghostlock-app/pull/118
> Commits (this branch, based on latest upstream `main` @ `7c63bb9`):
> 1. `kernels: add Nothing Phone (3a) Pro 6.1.157 offsets with kernel_phys_load 0xa8080000`
> 2. `app: prefer the fastest-core cpu pair by default`
> 3. `kernels: document kernel_phys_load provenance for the 3a Pro entry`
> 4. `app: guard fastest-core pair against offline sibling; label mixed freqs` (review feedback)
> 5. `app: rank online cores by frequency to pick the fastest pair` (review feedback)

---

## 1. Summary

Adds support for the **Nothing Phone (3a) Pro** (model `A059P`, product
`AsteroidsPro`, build `B4.1-260810-1153`, Android 16 / SDK 36 /
SPL 2026-08-01) on kernel
`6.1.157-android14-11-g82d681c9b06b-ab14634535`.

Offsets were extracted from the official boot.img of that exact build with
`extract_rs` and cross-verified byte-for-byte against a second, independently
device-verified exploit profile for the same kernel image (§4). Two further
findings had to be fixed before the exploit would run at all on this device:

1. **The kernel is physically loaded at `0xa8080000`, not the QC default
   `0xa8000000`** in `target.h` — a 0x80000 (one KASLR step) error that made
   every W1/W2 write land 0x80000 *below* its real target, corrupting kernel
   data and hanging the APPS core (QCOM watchdog bite → reboot).
2. **CPU-pair auto-selection fell back to little cores 0/1** on this SoC
   (SM7635: cpus 0-3 @1.8 GHz little, 4-6 @2.4 GHz, 7 @2.5 GHz). On little
   cores the route race loses more often; a lost race still performs the
   write into memory the allocator has since re-used (issue #78), which
   wedges the kernel.

## 2. Changes

| File | Change |
| --- | --- |
| `src/kernels/6.1.157-android14-11-g82d681c9b06b-ab14634535/offsets.h` | **new**: `OFFSETS_ENTRY` for the build incl. `.kernel_phys_load = 0xa8080000` override; provenance comment |
| `src/kernels/offsets.h` | add the `#include` of the new entry |
| `app/src/main/kotlin/.../AndroidGhostlockRepository.kt` | `buildCpuPairs()`: prefer the pair `(fastest, fastest-1)` instead of only chunking freq clusters (which drops an odd-sized top cluster, e.g. the prime core on 1+3+4 layouts) |

### Why `kernel_phys_load = 0xa8080000`?

- The A059P firmware ships the **same kernel image** as the A059 JP build
  (`boot.img` → decompressed Image sha256 `b344ddc1...1a73`, verified on both
  firmwares).
- For that image the physical load address was derived from the firmware's
  own `xbl_config.img` FDT ("Kernel" reserved region) as **`0xa8080000`** and
  device-verified end-to-end.
- GhostLock's QC default (`0xa8000000`) is exactly 0x80000 lower; the p0
  fingerprint/oracle then resolves the slide relative to the wrong base, so
  every write targets `target - 0x80000`.

The register step prints a generic "MediaTek default mismatch" warning for
any non-default phys; the emitted entry is still correct and carries the
explicit override (same mechanism as the existing `6.12.38-...-4k` entry).

## 3. Reproduction (before the fix)

Device: Nothing Phone (3a) Pro, stock `B4.1-260810-1153`, locked bootloader,
no root. App/CLI run with the freshly registered offsets but **without** the
two fixes:

- phys base `0xa8000000` (no override): W1 SELinux race hangs the kernel on
  the first TCP-route attempt; `qcom,gh-watchdog: Causing a QCOM Apps
  Watchdog bite` in pstore after ~90 s → reboot. Forcing
  `GHOSTLOCK_TCP_ROUTE=0` (pselect route) hangs even faster.
- phys base fixed but default cpu pair 0/1: W1 completes, W2 wedges around
  attempt 3.

With **both** fixes (`kernel_phys_load=0xa8080000` + cores 6/7):

```
W1: SELinux attempt 2/15 → Write 1 complete          (+3.9 s)
W2: attempt 1 miss → attempt 2 → "child uid = 0"     (+9.2 s)
[+] child is root!
[*] exploit complete                                   (+15.4 s)
```

No hang during the exploit; on the validation baseline the full flow also
completed with the KernelSU module late-loaded and SELinux restored to
enforcing, with the device stable afterwards.

## 4. Verification evidence

- **Offsets**: `extract_rs` output for the A059P boot.img equals, symbol for
  symbol, the Root-My-Device `target-core61.h` profile for the same kernel
  (independently derived and device-verified on A059 JP `B4.1-260618-1048`,
  whose boot.img decompresses to the identical Image sha256).
- **phys base**: `0xa8080000` from that profile's xbl-derived
  `P0_KERNEL_PHYS_LOAD`; DRAM memstart `0x80000000` re-confirmed in the A059P
  firmware's own `vendor_boot.img`/`dtbo.img`.
- **On-device**: CLI runs (`adb shell`, no seccomp → W3 skipped); SELinux
  flipped to permissive (W1 verify), child reached `uid 0` (W2 verify);
  full-success runs on the validation baseline incl. module late-load and
  `enforce=1` restore.

## 5. Residual risk (known, upstream issue #78)

A lost route race can still perform its write into reallocated memory; on
this device such a miss occasionally wedges the kernel instead of failing
cleanly. Same failure class as issue #78 — not introduced by this PR.
Recommendation: run on a fresh boot, save work first, reboot between
attempts.

## 6. Validation baseline & note for maintainers (upstream #115)

On-device validation was performed on upstream `8f8a8bb` (pre-#115). After
rebasing the same two commits onto current `main` (`35b9854`, which includes
#115 "fix kernelsnitch leak and collision handling"), behavior on this
**non-MTE** 6.1 kernel degraded. A/B over fresh-boot runs:

| Baseline (same offsets/phys/cores) | Result |
| --- | --- |
| `8f8a8bb` (pre-#115) | **2/2 full success** (W2 lands ~attempt 2, device stable) |
| `35b9854` (post-#115) | **0/4 clean success** (2× hang during W1 → watchdog reboot, 1× W2 15 rounds all miss, 1× W2 incomplete) |

Suspected cause: #115 removed the `mte_enabled` flag and now unconditionally
sweeps all 16 tag nibbles in `kernelsnitch.h __mm_leak()` (plus `| 0xf <<
56` on leaked pointers in `util.c`/`main.c`), which perturbs leak/collision
behavior on kernels without MTE.

The changes in this PR (offsets entry, default CPU pair) are **orthogonal to
#115** and correct on both baselines. Flagging the #115 observation here for
maintainers (no separate issue filed): if the unconditional tag sweep is not
intended for non-MTE devices, making it conditional on MTE detection again
would likely restore the pre-#115 behavior on this kernel family. Happy to
re-test on-device after any change.

## 7. How to verify on your side

```bash
# offsets (already committed here)
tools/extract_rs/target/release/ghostlock-extract.exe boot.img \
  --phys 0xa8080000 --force --register          # boot.img of B4.1-260810-1153

# CLI smoke test on the device (shell context, W3 skipped):
adb push ghostlock /data/local/tmp/ghostlock
adb shell chmod 755 /data/local/tmp/ghostlock
adb shell "cd /data/local/tmp && GHOSTLOCK_CORE=6 GHOSTLOCK_CONSUMER_CORE=7 \
  ./ghostlock"
# expect: W1 → Write 1 complete; W2 → "child uid = 0"; "child is root!"
```

Expected device identity (`getprop`): `ro.product.model=A059P`,
`ro.product.device=Asteroids`, `ro.product.product=AsteroidsPro`,
`ro.build.display.id=B4.1-260810-1153`, `uname -r=6.1.157-android14-11-g82d681c9b06b-ab14634535`.
