### PR TITLE
Add Lenovo Legion Y700 Wuji support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 | `6.12.30-android16-5-g6e872b4863d6-ab13847919-4k`      | REDMI Note 15 4G, POCO M6 Pro 4G                                 |
 | `6.12.38-android16-5-g1d46253471dd-ab15048002-4k`      | Motorola Razr Fold                                               |
 | `6.12.38-android16-5-g3c4da6410bcb-ab13872285-4k`      | Xiaomi 13T                                                       |
+| `6.12.38-android16-5-g74ad46052215-ab14494108-4k`      | Lenovo Legion Y700 Wuji                                          |
 | `6.12.38-android16-5-g844001fb8721-ab14552068-4k`      | OnePlus 15T                                                      |
 
 Kernels are matched by exact `uname -r`; unsupported builds are rejected and the app shows the status at the top. Offsets live in `src/kernels/<uname-release>/offsets.h` — add new builds with the extractor's `--register`.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -47,6 +47,7 @@
 | `6.12.30-android16-5-g6e872b4863d6-ab13847919-4k`      | REDMI Note 15 4G, POCO M6 Pro 4G                                 |
 | `6.12.38-android16-5-g1d46253471dd-ab15048002-4k`      | Motorola Razr Fold                                               |
 | `6.12.38-android16-5-g3c4da6410bcb-ab13872285-4k`      | Xiaomi 13T                                                       |
+| `6.12.38-android16-5-g74ad46052215-ab14494108-4k`      | Lenovo Legion Y700 Wuji                                          |
 | `6.12.38-android16-5-g844001fb8721-ab14552068-4k`      | OnePlus 15T                                                      |
 
 按精确 `uname -r` 匹配偏移表，未匹配的内核直接拒绝运行，App 顶部显示支持状态。偏移表在 `src/kernels/<uname-release>/offsets.h`，新内核构建用提取器的 `--register` 添加。

--- a/src/kernels/6.12.38-android16-5-g74ad46052215-ab14494108-4k/offsets.h
+++ b/src/kernels/6.12.38-android16-5-g74ad46052215-ab14494108-4k/offsets.h
@@ -1,0 +1,23 @@
+/* 6.12.38-android16-5-g74ad46052215-ab14494108-4k */
+
+OFFSETS_ENTRY(
+    "6.12.38-android16-5-g74ad46052215-ab14494108-4k",
+    STRUCT_OFFSETS_6_12,
+    .pselect_waiter_shift = 0,
+    .off_init_task = 0x0240cf00,
+    .off_init_cred = 0x02422c70,
+    .off_root_task_group = 0x0263d580,
+    .off_selinux_enforcing = 0x026894d0,
+    .off_selinux_blob_sizes = 0x018494e8,
+    .off_security_hook_heads = 0x00000000,
+    .off_slide_nfulnl_logger = 0x024021a0,
+    .off_slide_boot_id = 0x026aa868,
+    .off_slide_loggers_0_1 = 0x024020e8,
+),
+
+/* BTF reference (runtime uses target.h defaults): */
+/* #define STRUCT_PAGE_SIZE 0x40 */
+/* #define STRUCT_PAGE_COMPOUND_HEAD 0x8 */
+/* #define STRUCT_PAGE_TYPE 0x30 */
+/* #define STRUCT_SLAB_CACHE 0x8 */
+/* #define STRUCT_MM_STRUCT 0x4C0 */

--- a/src/kernels/offsets.h
+++ b/src/kernels/offsets.h
@@ -98,6 +98,7 @@ static const struct kernel_offsets known_offsets[] = {
 #include "6.12.30-android16-5-g6e872b4863d6-ab13847919-4k/offsets.h"
 #include "6.12.38-android16-5-g1d46253471dd-ab15048002-4k/offsets.h"
 #include "6.12.38-android16-5-g3c4da6410bcb-ab13872285-4k/offsets.h"
+#include "6.12.38-android16-5-g74ad46052215-ab14494108-4k/offsets.h"
 #include "6.12.38-android16-5-g844001fb8721-ab14552068-4k/offsets.h"
   { .uname_r = NULL }
 };


### PR DESCRIPTION
Add support for the 6.12.38-android16-5-g74ad46052215-ab14494108-4k kernel, used on the Lenovo Legion Y700 Wuji (TB324ZC).




<img width="1600" height="2560" alt="Screenshot_20260913-032242" src="https://github.com/user-attachments/assets/18c49d18-a1e5-41a1-9153-73b9c8bad4ea" />

<img width="1600" height="2560" alt="Screenshot_20260913-032248" src="https://github.com/user-attachments/assets/c97ee467-8bef-48e4-9eef-c766a71fbaec" />
